### PR TITLE
Patch: missed ghcr move elements

### DIFF
--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/_index.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/_index.md
@@ -86,6 +86,10 @@ PackageRevisions contain structured configuration files that can be modified thr
 
 KRM functions defined in the Kptfile automatically transform resources; they run when PackageRevisions are pushed to Porch. Common examples include `set-namespace`, `apply-replacements`, and `search-replace`.
 
+{{% alert title="Note" color="primary" %}}
+When specifying a function image in the Kptfile pipeline, you can use the shorthand form (e.g. `set-namespace:latest`) without a full container registry path. Porch will automatically resolve it using the default registry prefix configured in the Function Runner. You can also use the full image path (e.g. `ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest`) if you prefer to be explicit. To see which functions are available, run `kubectl get functionconfigs -n porch-fn-system`.
+{{% /alert %}}
+
 **Content Structure:**
 
 ```bash

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/cloning-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/cloning-packages.md
@@ -134,7 +134,7 @@ upstream:
     ref: main
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: set-namespace:latest
       configMap:
         namespace: production
 ```

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/copying-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/copying-packages.md
@@ -137,7 +137,7 @@ info:
   description: My app version 2 with improvements
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: set-namespace:latest
       configMap:
         namespace: production
 ```

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/creating-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/creating-packages.md
@@ -124,7 +124,7 @@ info:
   description: My first Porch package
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: set-namespace:latest
       configMap:
         namespace: production
 ```
@@ -171,8 +171,8 @@ This command updates the PackageRevision in Porch and triggers rendering (execut
 Successful output should look like a following. This describes how the KRM function was run by Porch and has updated the namespace in our new configmap.
 
 ```bash
-[RUNNING] "gcr.io/kpt-fn/set-namespace:v0.4.1"
-[PASS] "gcr.io/kpt-fn/set-namespace:v0.4.1"
+[RUNNING] "set-namespace:latest"
+[PASS] "set-namespace:latest"
   Results:
     [info]: namespace "" updated to "production", 1 value(s) changed
 porch-test.my-first-package.v1 pushed

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md
@@ -126,7 +126,7 @@ info:
   description: My application package
 pipeline:
   mutators:
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.5
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     configMap:
       namespace: production
 status:
@@ -179,7 +179,7 @@ items:
     description: My first Porch package
   pipeline:
     mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: set-namespace:latest
       configMap:
         namespace: production
 - apiVersion: v1

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/upgrading-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/upgrading-packages.md
@@ -94,7 +94,7 @@ porchctl rpkg clone porch-test.blueprint.1 --namespace=porch-demo --repository=p
 porchctl rpkg pull porch-test.deployment.1 --namespace=porch-demo ./tmp/deployment-v1
 
 # Apply a local customization (e.g., add an annotation to the Kptfile)
-kpt fn eval --image set-annotations:latest ./tmp/deployment-v1/Kptfile -- kpt.dev/annotation=true
+kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest ./tmp/deployment-v1/Kptfile -- kpt.dev/annotation=true
 
 # Push the local changes back to Porch
 porchctl rpkg push porch-test.deployment.1 --namespace=porch-demo ./tmp/deployment-v1

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/upgrading-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/upgrading-packages.md
@@ -94,7 +94,7 @@ porchctl rpkg clone porch-test.blueprint.1 --namespace=porch-demo --repository=p
 porchctl rpkg pull porch-test.deployment.1 --namespace=porch-demo ./tmp/deployment-v1
 
 # Apply a local customization (e.g., add an annotation to the Kptfile)
-kpt fn eval --image gcr.io/kpt-fn/set-annotations:v0.1.4 ./tmp/deployment-v1/Kptfile -- kpt.dev/annotation=true
+kpt fn eval --image set-annotations:latest ./tmp/deployment-v1/Kptfile -- kpt.dev/annotation=true
 
 # Push the local changes back to Porch
 porchctl rpkg push porch-test.deployment.1 --namespace=porch-demo ./tmp/deployment-v1

--- a/docs/content/en/docs/5_architecture_and_components/function-runner/functionality/image-registry-management.md
+++ b/docs/content/en/docs/5_architecture_and_components/function-runner/functionality/image-registry-management.md
@@ -121,7 +121,7 @@ Image Reference
 ```
 
 **Authentication decision:**
-- **Default registry** (gcr.io/kpt-fn/): Uses default keychain
+- **Default registry** (ghcr.io/kptdev/krm-functions-catalog/): Uses default keychain
 - **Custom registry**: Requires private registry support enabled
 - **Disabled private registries**: Falls back to default keychain
 

--- a/docs/content/en/docs/5_architecture_and_components/function-runner/interactions.md
+++ b/docs/content/en/docs/5_architecture_and_components/function-runner/interactions.md
@@ -263,7 +263,7 @@ Pod Creation
 The Function Runner supports private registries with authentication:
 
 **Authentication flow:**
-- Default registry (gcr.io/kpt-fn/) uses default keychain
+- Default registry (ghcr.io/kptdev/krm-functions-catalog/) uses default keychain
 - Custom registries use Docker config JSON format
 - Auth secret mounted into Function Runner pod
 - Image pull secrets created and attached to function pods

--- a/docs/content/en/docs/6_configuration_and_deployments/deployments/catalog-deployment.md
+++ b/docs/content/en/docs/6_configuration_and_deployments/deployments/catalog-deployment.md
@@ -67,7 +67,7 @@ If you need any pre-deployment features from the [Configuration Planning](#confi
 cd porch/
 
 # Example: Configure database cache for Porch Server
-kpt fn eval --image set-annotations:latest -- \
+kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest -- \
   annotations='cache-type=DB'
 
 # Review your changes

--- a/docs/content/en/docs/6_configuration_and_deployments/deployments/catalog-deployment.md
+++ b/docs/content/en/docs/6_configuration_and_deployments/deployments/catalog-deployment.md
@@ -67,7 +67,7 @@ If you need any pre-deployment features from the [Configuration Planning](#confi
 cd porch/
 
 # Example: Configure database cache for Porch Server
-kpt fn eval --image gcr.io/kpt-fn/set-annotations:v0.1 -- \
+kpt fn eval --image set-annotations:latest -- \
   annotations='cache-type=DB'
 
 # Review your changes

--- a/func/internal/podcachemanager_eventloop_test.go
+++ b/func/internal/podcachemanager_eventloop_test.go
@@ -254,7 +254,7 @@ func TestEventLoop_PodFailedNoRedistribution(t *testing.T) {
 	pcm, reqCh, _ := newTestEventLoopPCM(kubeClient)
 
 	// Pre-populate imageMetadataCache so imageDigestAndEntrypoint returns instantly
-	pcm.podManager.imageMetadataCache.Store("gcr.io/kpt-fn/test-fn:latest", &digestAndEntrypoint{
+	pcm.podManager.imageMetadataCache.Store("ghcr.io/kptdev/krm-functions-catalog/test-fn:latest", &digestAndEntrypoint{
 		digest:     "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
 		entrypoint: []string{"/test-fn"},
 	})
@@ -264,7 +264,7 @@ func TestEventLoop_PodFailedNoRedistribution(t *testing.T) {
 	// Send connectionRequest — triggers scale-up → goroutine → CreatePod fails → error response
 	responseCh := make(chan *connectionResponse, 1)
 	reqCh <- &connectionRequest{
-		image:      "gcr.io/kpt-fn/test-fn:latest",
+		image:      "ghcr.io/kptdev/krm-functions-catalog/test-fn:latest",
 		responseCh: responseCh,
 	}
 

--- a/func/internal/podevaluator.go
+++ b/func/internal/podevaluator.go
@@ -41,7 +41,7 @@ const (
 	fieldManagerName          = "krm-function-runner"
 	functionContainerName     = "function"
 	defaultManagerNamespace   = "porch-system"
-	defaultRegistry           = "gcr.io/kpt-fn/"
+	defaultRegistry           = "ghcr.io/kptdev/krm-functions-catalog/"
 	serviceDnsNameSuffix      = ".svc.cluster.local"
 	channelBufferSize         = 128
 )

--- a/func/internal/podmanager.go
+++ b/func/internal/podmanager.go
@@ -891,7 +891,6 @@ func podID(image, hash, postFix string) (string, error) {
 		return "", fmt.Errorf("unable to parse image reference %v: %w", image, err)
 	}
 
-	// repoName will be something like ghcr.io/kptdev/krm-functions-catalog/set-namespace
 	repoName := ref.Context().Name()
 	tag := strings.ReplaceAll(ref.Identifier(), ".", "")
 	parts := strings.Split(repoName, "/")

--- a/func/internal/podmanager.go
+++ b/func/internal/podmanager.go
@@ -891,6 +891,7 @@ func podID(image, hash, postFix string) (string, error) {
 		return "", fmt.Errorf("unable to parse image reference %v: %w", image, err)
 	}
 
+	// repoName will be something like ghcr.io/kptdev/krm-functions-catalog/...
 	repoName := ref.Context().Name()
 	tag := strings.ReplaceAll(ref.Identifier(), ".", "")
 	parts := strings.Split(repoName, "/")

--- a/func/internal/podmanager.go
+++ b/func/internal/podmanager.go
@@ -891,7 +891,7 @@ func podID(image, hash, postFix string) (string, error) {
 		return "", fmt.Errorf("unable to parse image reference %v: %w", image, err)
 	}
 
-	// repoName will be something like gcr.io/kpt-fn/set-namespace
+	// repoName will be something like ghcr.io/kptdev/krm-functions-catalog/set-namespace
 	repoName := ref.Context().Name()
 	tag := strings.ReplaceAll(ref.Identifier(), ".", "")
 	parts := strings.Split(repoName, "/")

--- a/func/internal/podmanager_unit_test.go
+++ b/func/internal/podmanager_unit_test.go
@@ -48,28 +48,28 @@ func TestPodID(t *testing.T) {
 	}{
 		{
 			name:     "standard image with tag",
-			image:    "gcr.io/kpt-fn/apply-replacements:latest",
+			image:    "ghcr.io/kptdev/krm-functions-catalog/apply-replacements:latest",
 			hash:     "5245a52778d684fa698f69861fb2e058b308f6a74fed5bf2fe77d97bad5e071c",
 			postFix:  "1",
 			expected: "apply-replacements-latest-1-5245a527",
 		},
 		{
 			name:     "image without explicit tag defaults to latest",
-			image:    "gcr.io/kpt-fn/set-namespace",
+			image:    "ghcr.io/kptdev/krm-functions-catalog/set-namespace",
 			hash:     "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 			postFix:  "2",
 			expected: "set-namespace-latest-2-abcdef12",
 		},
 		{
 			name:     "image with version tag containing dots",
-			image:    "gcr.io/kpt-fn/set-labels:v0.4.1",
+			image:    "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.4.1",
 			hash:     "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 			postFix:  "1",
 			expected: "set-labels-v041-1-12345678",
 		},
 		{
 			name:     "image with underscores in name",
-			image:    "gcr.io/kpt-fn/my_function:latest",
+			image:    "ghcr.io/kptdev/krm-functions-catalog/my_function:latest",
 			hash:     "aabbccddee112233aabbccddee112233aabbccddee112233aabbccddee112233",
 			postFix:  "1",
 			expected: "my-function-latest-1-aabbccdd",
@@ -235,11 +235,11 @@ func TestPatchNewPodContainer(t *testing.T) {
 			entrypoint: []string{"/my-function"},
 		}
 
-		err := pm.patchNewPodContainer(podTemplateSpec, de, "gcr.io/kpt-fn/my-function:latest")
+		err := pm.patchNewPodContainer(podTemplateSpec, de, "ghcr.io/kptdev/krm-functions-catalog/my-function:latest")
 		require.NoError(t, err)
 
 		container := podTemplateSpec.Spec.Containers[0]
-		assert.Equal(t, "gcr.io/kpt-fn/my-function:latest", container.Image)
+		assert.Equal(t, "ghcr.io/kptdev/krm-functions-catalog/my-function:latest", container.Image)
 		assert.Contains(t, container.Args, "--port")
 		assert.Contains(t, container.Args, defaultWrapperServerPort)
 		assert.Contains(t, container.Args, "--")


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

## Title
<!-- Short, descriptive title for the PR -->
Patch missed ghcr move elements

---

## Description
<!-- Describe what this PR does and why -->
- What changed:  docs + prefix + unit test usage of gcr instead of ghcr missed in #982 
- Why it’s needed:  following the current tutorials will lead to image pull failures and failed renders. attempting to use prefix to get around this will also fail as it leads to old gcr instead. one unit test seemed to use the old one also but i believe it was just in string not literal change
- How it works:  docs now explain note of prefix and how to use. + changed to use prefix by default & latest image also for simplicity.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #  

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Tests added/updated  
- [x] Documentation added/updated  
- [x] All tests and gating checks pass  

---

## Testing Instructions (Optional)
1.  check the docs 
2.  ensure prefix correctly reroutes to ghcr now instead of gcr
3.  unit test pass

---

## Additional Notes (Optional)
- Known issues:  
- Further improvements:  
- Review notes:  

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Once discovered i used kiro to scan the docs area for usage of gcr.
