### PR TITLE
Clear the status of the subpackage Kptfile on subpackage clones and upgrades

### DIFF
--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -280,7 +280,7 @@ func (th *genericTaskHandler) applySubpackageTask(
 
 	subpackageName, _ := porchapi.ComposeSubpkgObjName(subpackageDir)
 	if err := kptFile.SetName(subpackageName); err != nil {
-		return pkgerrors.Wrapf(err, "failed to write package name %q to subpackage Kptfile", subpackageName)
+		return pkgerrors.Wrapf(err, "failed to write package name %q to subpackage Kptfile %q", subpackageName, path.Join(subpackageDir, kptfilev1.KptFileName))
 	}
 
 	if err := kptFile.ClearStatus(); err != nil {
@@ -288,7 +288,7 @@ func (th *genericTaskHandler) applySubpackageTask(
 	}
 
 	if err := kptFile.WriteToPackage(subpackageResources.Contents); err != nil {
-		return pkgerrors.Wrapf(err, "failed to write package name %q to subpackage Kptfile", subpackageName)
+		return pkgerrors.Wrapf(err, "failed to write to subpackage Kptfile %q", path.Join(subpackageDir, kptfilev1.KptFileName))
 	}
 
 	// Remove the subpackage task to prevent re-execution of the task

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -283,8 +283,12 @@ func (th *genericTaskHandler) applySubpackageTask(
 		return pkgerrors.Wrapf(err, "failed to write package name %q to subpackage Kptfile", subpackageName)
 	}
 
+	if err := kptFile.ClearStatus(); err != nil {
+		return pkgerrors.Wrapf(err, "failed to write package name %q to subpackage Kptfile", subpackageName)
+	}
+
 	if err := kptFile.WriteToPackage(subpackageResources.Contents); err != nil {
-		return pkgerrors.Wrapf(err, "failed to write to subpackage Kptfile %q", path.Join(subpackageDir, kptfilev1.KptFileName))
+		return pkgerrors.Wrapf(err, "failed to clear status in Kptfile %q", path.Join(subpackageDir, kptfilev1.KptFileName))
 	}
 
 	// Remove the subpackage task to prevent re-execution of the task

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -284,11 +284,11 @@ func (th *genericTaskHandler) applySubpackageTask(
 	}
 
 	if err := kptFile.ClearStatus(); err != nil {
-		return pkgerrors.Wrapf(err, "failed to write package name %q to subpackage Kptfile", subpackageName)
+		return pkgerrors.Wrapf(err, "failed to clear status in Kptfile %q", path.Join(subpackageDir, kptfilev1.KptFileName))
 	}
 
 	if err := kptFile.WriteToPackage(subpackageResources.Contents); err != nil {
-		return pkgerrors.Wrapf(err, "failed to clear status in Kptfile %q", path.Join(subpackageDir, kptfilev1.KptFileName))
+		return pkgerrors.Wrapf(err, "failed to write package name %q to subpackage Kptfile", subpackageName)
 	}
 
 	// Remove the subpackage task to prevent re-execution of the task

--- a/pkg/task/generictaskhandler_test.go
+++ b/pkg/task/generictaskhandler_test.go
@@ -1416,8 +1416,96 @@ func TestApplySubpackageTask_InvalidSubpackageName(t *testing.T) {
 
 	err := th.applySubpackageTask(context.Background(), draft, obj, repository.PackageResources{Contents: map[string]string{}})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "subpackage resource name")
-	assert.Contains(t, err.Error(), "lowercase RFC 1123 subdomain")
+	require.Contains(t, err.Error(), "subpackage resource name")
+}
+
+func TestApplySubpackageTask_CheckTaskStatusCleared(t *testing.T) {
+	// SubpackageDir that produces an invalid k8s name (uppercase letters)
+	upstreamPrKey := repository.PackageRevisionKey{
+		PkgKey: repository.PackageKey{
+			RepoKey: repository.RepositoryKey{
+				Namespace: "default",
+				Name:      "upstream-repo",
+			},
+			Package: "subpkg",
+		},
+		WorkspaceName: "ws",
+		Revision:      1,
+	}
+
+	upstreamPR := &fakeextrepo.FakePackageRevision{
+		PrKey: upstreamPrKey,
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: map[string]string{
+					"Kptfile": "apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: subpkg\nstatus:\n  conditions:\n",
+				},
+			},
+		},
+		Kptfile: kptfilev1.KptFile{
+			Upstream: &kptfilev1.Upstream{
+				Type: kptfilev1.GitOrigin,
+				Git:  &kptfilev1.Git{Repo: "https://github.com/example/repo.git", Ref: "main", Directory: "/subpkg"},
+			},
+			UpstreamLock: &kptfilev1.Locator{
+				Type: kptfilev1.GitOrigin,
+				Git:  &kptfilev1.GitLock{Repo: "https://github.com/example/repo.git", Ref: "main", Directory: "/subpkg", Commit: "abc123"},
+			},
+		},
+	}
+
+	fakeRepo := &fakeextrepo.Repository{
+		PackageRevisions: []repository.PackageRevision{upstreamPR},
+	}
+
+	obj := &porchapi.PackageRevision{
+		Spec: porchapi.PackageRevisionSpec{
+			Tasks: []porchapi.Task{
+				{Type: porchapi.TaskTypeClone, Clone: &porchapi.PackageCloneTaskSpec{}},
+				{
+					Type: porchapi.TaskTypeClone,
+					Clone: &porchapi.PackageCloneTaskSpec{
+						SubpackageDir: "my-subpackage",
+						Upstream: porchapi.UpstreamPackage{
+							UpstreamRef: &porchapi.PackageRevisionRef{
+								Name: "upstream-repo.subpkg.ws",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	draft := &fakeextrepo.FakePackageRevision{
+		PrKey: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Namespace: "default",
+					Name:      "test-repo",
+				},
+				Package: "test-pkg",
+			},
+			WorkspaceName: "ws",
+		},
+		Resources: &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: map[string]string{},
+			},
+		},
+	}
+
+	th := &genericTaskHandler{
+		referenceResolver: &mockReferenceResolver{repo: &configapi.Repository{}},
+		repoOpener:        &mockRepositoryOpener{repo: fakeRepo},
+	}
+
+	resources := repository.PackageResources{Contents: map[string]string{}}
+
+	err := th.applySubpackageTask(context.Background(), draft, obj, resources)
+	require.Nil(t, err)
+	require.Contains(t, upstreamPR.Resources.Spec.Resources[kptfilev1.KptFileName], "\nstatus:")
+	require.NotContains(t, resources.Contents["my-subpackage/"+kptfilev1.KptFileName], "\nstatus:")
 }
 
 type mockReferenceResolver struct {

--- a/pkg/task/generictaskhandler_test.go
+++ b/pkg/task/generictaskhandler_test.go
@@ -1419,7 +1419,7 @@ func TestApplySubpackageTask_InvalidSubpackageName(t *testing.T) {
 	require.Contains(t, err.Error(), "subpackage resource name")
 }
 
-func TestApplySubpackageTask_CheckTaskStatusCleared(t *testing.T) {
+func TestApplySubpackageTask_CheckKptfileStatusCleared(t *testing.T) {
 	// SubpackageDir that produces an invalid k8s name (uppercase letters)
 	upstreamPrKey := repository.PackageRevisionKey{
 		PkgKey: repository.PackageKey{
@@ -1438,7 +1438,7 @@ func TestApplySubpackageTask_CheckTaskStatusCleared(t *testing.T) {
 		Resources: &porchapi.PackageRevisionResources{
 			Spec: porchapi.PackageRevisionResourcesSpec{
 				Resources: map[string]string{
-					"Kptfile": "apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: subpkg\nstatus:\n  conditions:\n",
+					kptfilev1.KptFileName: "apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: subpkg\nstatus:\n  conditions:\n",
 				},
 			},
 		},
@@ -1503,7 +1503,7 @@ func TestApplySubpackageTask_CheckTaskStatusCleared(t *testing.T) {
 	resources := repository.PackageResources{Contents: map[string]string{}}
 
 	err := th.applySubpackageTask(context.Background(), draft, obj, resources)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Contains(t, upstreamPR.Resources.Spec.Resources[kptfilev1.KptFileName], "\nstatus:")
 	require.NotContains(t, resources.Contents["my-subpackage/"+kptfilev1.KptFileName], "\nstatus:")
 }


### PR DESCRIPTION
# Clear the status of the subpackage Kptfile on subpackage clones and upgrades

---

## Description
- What changed: The status of a Kptfile in a cloned or upgraded package is cleared on subpackage clones and upgrades
- Why it’s needed: The status in the upstream Kptfile belongs to the upstram PR, the cloend subpackage has a new lifecycle and a new status
- How it works: The status is cleared

---

## Related Issue(s)
- Closes/Fixes #1109

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**
