### PR TITLE
Add additional E2E testing for subpackage interactions

### DIFF
--- a/test/e2e/api/rpkg_subpkg_render_test.go
+++ b/test/e2e/api/rpkg_subpkg_render_test.go
@@ -48,8 +48,8 @@ var (
 
 // Setup:
 //   - 3 subpackages: 1, 2, and 3 (to be discovered in that order when rendering)
-//   - kpt.dev/save-on-render-failure: "true" in root Kptfile
-//   - kpt.dev/bfs-rendering: "true" in root Kptfile
+//   - kpt.dev/save-on-render-failure: "true" in parent package's Kptfile
+//   - kpt.dev/bfs-rendering: "true" in parent package's Kptfile
 //
 // When:
 //   - subpackage 1 renders OK
@@ -67,16 +67,10 @@ func (t *PorchSuite) TestSaveOnFailureSubpackageRenderHandling() {
 	)
 	parentPR := t.setupSubpackageRenderingTestScenario(repo, subpackageDir1, subpackageDir2, subpackageDir3)
 
-	var parentPRResources porchapiv1alpha1.PackageRevisionResources
-	t.GetF(client.ObjectKey{
-		Namespace: t.Namespace,
-		Name:      parentPR.Name,
-	}, &parentPRResources)
-
 	parentPR.Annotations = map[string]string{porchPushOnRenderFailure: "true"}
 	t.UpdateF(parentPR)
 
-	err := t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	err := t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		// Modify my-subpackage-1's Kptfile to set a label on my-subpackage-1's resources
 		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
 			Image: starlarkImage,
@@ -123,13 +117,18 @@ subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
 	})
 	assert.NoError(t, err)
 
+	var parentPRResources porchapiv1alpha1.PackageRevisionResources
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 
-	// Modify the root Kptfile to save on render failure and to render in BFS order
+	// Modify the parent package's Kptfile to set save-on-render-failure and render order annotations
 	// (this also triggers the render which will encounter the error part-way through)
-	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	err = t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		maps.Insert(kptfile.Annotations, saveOnRenderFailure)
 		maps.Insert(kptfile.Annotations, renderOrder)
 	})
@@ -140,20 +139,20 @@ subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	// modifications to subpackage 1 are present
+	// Modifications to subpackage 1 are present
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
-	// modifications to subpackage 2 before the erroring function are present
+	// Modifications to subpackage 2 before the erroring function are present
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
-	// modifications to subpackage 2 after the erroring function are not present
+	// Modifications to subpackage 2 after the erroring function are not present
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test-2: modification-2")
-	// modifications to subpackage 3 are not present
+	// Modifications to subpackage 3 are not present
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 }
 
 // Setup:
 //   - 3 subpackages: 1, 2, and 3 (to be discovered in that order when rendering)
-//   - kpt.dev/save-on-render-failure: "false" in root Kptfile
-//   - kpt.dev/bfs-rendering: "true" in root Kptfile
+//   - kpt.dev/save-on-render-failure: "false" in parent package's Kptfile
+//   - kpt.dev/bfs-rendering: "true" in parent package's Kptfile
 //
 // When:
 //   - subpackage 1 renders OK
@@ -170,7 +169,7 @@ func (t *PorchSuite) TestNoSaveOnFailureSubpackageRenderHandling() {
 
 	parentPR.Annotations = map[string]string{porchPushOnRenderFailure: "true"}
 	t.UpdateF(parentPR)
-	err := t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	err := t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		// Modify my-subpackage-1's Kptfile to set a label on my-subpackage-1's resources
 		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
 			Image: starlarkImage,
@@ -195,6 +194,7 @@ subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
 		// the root-plus-subpackages render
 		injectErrorInSubpackageKptfile(subpackageDir2, kptfile)
 
+		// Modify my-subpackage-3's Kptfile to set a label on my-subpackage-3's resources
 		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
 			Image: starlarkImage,
 			Selectors: []kptfilev1.Selector{{
@@ -225,9 +225,9 @@ subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 
-	// Modify the root Kptfile to save on render failure and to render in BFS order
+	// Modify the parent package's Kptfile to set save-on-render-failure and render order annotations
 	// (this also triggers the render which will encounter the error part-way through)
-	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	err = t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		maps.Insert(kptfile.Annotations, saveOnRenderFailure)
 		maps.Insert(kptfile.Annotations, renderOrder)
 	})
@@ -238,7 +238,7 @@ subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	// no modifications are present
+	// No modifications are present
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test-2: modification-2")
@@ -270,7 +270,7 @@ func (t *PorchSuite) TestSaveOnParentFailureSubpackageRenderHandling() {
 
 	parentPR.Annotations = map[string]string{porchPushOnRenderFailure: "true"}
 	t.UpdateF(parentPR)
-	err := t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	err := t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		for _, subpkg := range []string{subpackageDir1, subpackageDir2, subpackageDir3} {
 			kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
 				Image: starlarkImage,
@@ -335,7 +335,9 @@ i = 10/0
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 
-	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	// Modify the parent package's Kptfile to set save-on-render-failure and render order annotations
+	// (this also triggers the render which will encounter the error part-way through)
+	err = t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		maps.Insert(kptfile.Annotations, saveOnRenderFailure)
 		maps.Insert(kptfile.Annotations, renderOrder)
 	})
@@ -345,14 +347,14 @@ i = 10/0
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	// modifications to subpackages are all present
+	// Modifications to subpackages are all present
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1", "my-subpackage-1 does not contain the subpackage-render-test label")
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1", "my-subpackage-2 does not contain the subpackage-render-test label")
 	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1", "my-subpackage-3 does not contain the subpackage-render-test label")
 
-	// modifications to parent package before the erroring function are present
+	// Modifications to parent package before the erroring function are present
 	assert.Contains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "subpackage-render-test: modification-1", "parent-package does not contain the subpackage-render-test label")
-	// modifications to parent package after the erroring function are not present
+	// Modifications to parent package after the erroring function are not present
 	assert.NotContains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "subpackage-render-test-2: modification-2", "parent-package contains the subpackage-render-test-2 label")
 }
 
@@ -377,7 +379,7 @@ func (t *PorchSuite) TestNoSaveOnParentFailureSubpackageRenderHandling() {
 	)
 	parentPR := t.setupSubpackageRenderingTestScenario(repo, subpackageDir1, subpackageDir2, subpackageDir3)
 
-	err := t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	err := t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		for _, subpkg := range []string{subpackageDir1, subpackageDir2, subpackageDir3} {
 			kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
 				Image: starlarkImage,
@@ -442,7 +444,9 @@ i = 10/0
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 
-	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	// Modify the parent package's Kptfile to set save-on-render-failure and render order annotations
+	// (this also triggers the render which will encounter the error part-way through)
+	err = t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		maps.Insert(kptfile.Annotations, saveOnRenderFailure)
 		maps.Insert(kptfile.Annotations, renderOrder)
 	})
@@ -452,7 +456,7 @@ i = 10/0
 		Name:      parentPR.Name,
 	}, &parentPRResources)
 
-	// no modifications are present
+	// No modifications are present
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
 	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
@@ -473,7 +477,7 @@ func (t *PorchSuite) TestBreadthFirstOrderSubpackageRenderHandling() {
 	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repo, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
 
 	cloneePR1V1 := t.createPR(repo, cloneePackageName+"-1", clonedWorkspaceV1)
-	err := t.UpdateKptfileF(cloneePR1V1, func(kptfile *kptfilev1.KptFile) {
+	err := t.UpdateKptfile(cloneePR1V1, func(kptfile *kptfilev1.KptFile) {
 		// Set subpackage's render order to BFS
 		maps.Insert(kptfile.Annotations, kptBFSRenderOrder)
 
@@ -500,7 +504,7 @@ file.get("metadata", {}).get("labels", {})["subpackage-render-test-timestamp"] =
 	parentPR, err = t.cloneSubpackage(parentPR, cloneePR1V1, subpackageDir1)
 	assert.NoError(t, err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR1V1, parentPR, subpackageDir1, err)
 
-	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	err = t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		// Add a script in parent package to set a timestamp and track time of render
 		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
 			Image: starlarkImage,
@@ -520,7 +524,7 @@ file.get("metadata", {}).get("labels", {})["subpackage-render-test-timestamp"] =
 	require.NoError(t.T(), err)
 
 	// Insert a meaningless annotation in parent package's Kptfile to trigger a render
-	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	err = t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		maps.Insert(kptfile.Annotations, maps.All(map[string]string{"something": "some-value"}))
 	})
 	require.NoError(t.T(), err)
@@ -539,7 +543,9 @@ file.get("metadata", {}).get("labels", {})["subpackage-render-test-timestamp"] =
 	// (also showing that DFS rendering is default)
 	assert.Greater(t, parentRenderTime, subpackageRenderTime)
 
-	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	// Modify the parent package's Kptfile to set the render order annotation
+	// (this also triggers the render)
+	err = t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		maps.Insert(kptfile.Annotations, kptBFSRenderOrder)
 	})
 	require.NoError(t.T(), err)
@@ -568,7 +574,7 @@ func (t *PorchSuite) TestDepthFirstOrderSubpackageRenderHandling() {
 	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repo, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
 
 	cloneePR1V1 := t.createPR(repo, cloneePackageName+"-1", clonedWorkspaceV1)
-	err := t.UpdateKptfileF(cloneePR1V1, func(kptfile *kptfilev1.KptFile) {
+	err := t.UpdateKptfile(cloneePR1V1, func(kptfile *kptfilev1.KptFile) {
 		// Set subpackage's render order to DFS
 		maps.Insert(kptfile.Annotations, kptDFSRenderOrder)
 
@@ -595,7 +601,7 @@ file.get("metadata", {}).get("labels", {})["subpackage-render-test-timestamp"] =
 	parentPR, err = t.cloneSubpackage(parentPR, cloneePR1V1, subpackageDir1)
 	assert.NoError(t, err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR1V1, parentPR, subpackageDir1, err)
 
-	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	err = t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		// Add a script in parent package to set a timestamp and track time of render
 		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
 			Image: starlarkImage,
@@ -615,7 +621,7 @@ file.get("metadata", {}).get("labels", {})["subpackage-render-test-timestamp"] =
 	require.NoError(t.T(), err)
 
 	// Insert a meaningless annotation in parent package's Kptfile to trigger a render
-	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	err = t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		maps.Insert(kptfile.Annotations, maps.All(map[string]string{"something": "some-value"}))
 	})
 	require.NoError(t.T(), err)
@@ -629,12 +635,12 @@ file.get("metadata", {}).get("labels", {})["subpackage-render-test-timestamp"] =
 	subpackageRenderTime := t.extractRenderTimestamp(parentPRResources, subpackageDir1+"/my-configmap.yaml")
 
 	// Greater parent render time shows that parent was rendered AFTER subpackage,
-	// showing that BFS annotation in subpackage had no effect in render done through
-	// parent package.
 	// (also showing that DFS rendering is default)
 	assert.Greater(t, parentRenderTime, subpackageRenderTime)
 
-	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+	// Modify the parent package's Kptfile to set the render order annotation
+	// (this also triggers the render)
+	err = t.UpdateKptfile(parentPR, func(kptfile *kptfilev1.KptFile) {
 		maps.Insert(kptfile.Annotations, kptDFSRenderOrder)
 	})
 	require.NoError(t.T(), err)

--- a/test/e2e/api/rpkg_subpkg_render_test.go
+++ b/test/e2e/api/rpkg_subpkg_render_test.go
@@ -1,0 +1,720 @@
+// Copyright 2026 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"maps"
+	"time"
+
+	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
+	porchapiv1alpha1 "github.com/kptdev/porch/api/porch/v1alpha1"
+	suiteutils "github.com/kptdev/porch/test/e2e/suiteutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+const (
+	starlarkImage  = "ghcr.io/kptdev/krm-functions-catalog/starlark:latest"
+	setLabelsImage = "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+
+	// note: to take effect, must be applied as annotation directly on PackageRevision (not in PackageRevisionResources's Kptfile):
+	porchPushOnRenderFailure = "porch.kpt.dev/push-on-render-failure"
+	repo                     = "subpkg-file-operations"
+	subpackageDir1           = "my-subpackage-1"
+	subpackageDir2           = "my-subpackage-2"
+	subpackageDir3           = "my-subpackage-3"
+)
+
+var (
+	kptSaveOnRenderFailure   = maps.All(map[string]string{"kpt.dev/save-on-render-failure": "true"})
+	kptNoSaveOnRenderFailure = maps.All(map[string]string{"kpt.dev/save-on-render-failure": "false"})
+	kptBFSRenderOrder        = maps.All(map[string]string{"kpt.dev/bfs-rendering": "true"})
+	kptDFSRenderOrder        = maps.All(map[string]string{"kpt.dev/bfs-rendering": "false"})
+)
+
+// Setup:
+//   - 3 subpackages: 1, 2, and 3 (to be discovered in that order when rendering)
+//   - kpt.dev/save-on-render-failure: "true" in root Kptfile
+//   - kpt.dev/bfs-rendering: "true" in root Kptfile
+//
+// When:
+//   - subpackage 1 renders OK
+//   - subpackage 2 renders partially, then encounters an error
+//
+// Then:
+//   - modifications to subpackage 1 are preserved
+//   - modifications to subpackage 2 before the error are preserved
+//   - modifications to subpackage 2 after the error are not preserved
+//   - modifications to subpackage 3 are neither performed nor preserved
+func (t *PorchSuite) TestSaveOnFailureSubpackageRenderHandling() {
+	var (
+		saveOnRenderFailure = kptSaveOnRenderFailure
+		renderOrder         = kptBFSRenderOrder
+	)
+	parentPR := t.setupSubpackageRenderingTestScenario(repo, subpackageDir1, subpackageDir2, subpackageDir3)
+
+	var parentPRResources porchapiv1alpha1.PackageRevisionResources
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	parentPR.Annotations = map[string]string{porchPushOnRenderFailure: "true"}
+	t.UpdateF(parentPR)
+
+	err := t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		// Modify my-subpackage-1's Kptfile to set a label on my-subpackage-1's resources
+		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+			Image: starlarkImage,
+			Selectors: []kptfilev1.Selector{{
+				Kind: kptfilev1.KptFileGVK().Kind,
+				Name: subpackageDir1,
+			}},
+			ConfigMap: map[string]string{
+				"source": `
+subpkgKptfile = ctx.resource_list["items"][0]
+subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test": "modification-1"
+	},
+}])
+				`,
+			},
+		})
+
+		// Modify my-subpackage-2's Kptfile to set a label on my-subpackage-2's resources, then error out and interrupt
+		// the root-plus-subpackages render
+		injectErrorInSubpackageKptfile(subpackageDir2, kptfile)
+
+		// Modify my-subpackage-3's Kptfile to set a label on my-subpackage-3's resources
+		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+			Image: starlarkImage,
+			Selectors: []kptfilev1.Selector{{
+				Kind: kptfilev1.KptFileGVK().Kind,
+				Name: subpackageDir3,
+			}},
+			ConfigMap: map[string]string{
+				"source": `
+subpkgKptfile = ctx.resource_list["items"][0]
+subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test": "modification-1"
+	},
+}])
+				`,
+			},
+		})
+	})
+	assert.NoError(t, err)
+
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+
+	// Modify the root Kptfile to save on render failure and to render in BFS order
+	// (this also triggers the render which will encounter the error part-way through)
+	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		maps.Insert(kptfile.Annotations, saveOnRenderFailure)
+		maps.Insert(kptfile.Annotations, renderOrder)
+	})
+
+	assert.ErrorContains(t, err, "Deliberate error!")
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	// modifications to subpackage 1 are present
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	// modifications to subpackage 2 before the erroring function are present
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	// modifications to subpackage 2 after the erroring function are not present
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test-2: modification-2")
+	// modifications to subpackage 3 are not present
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+}
+
+// Setup:
+//   - 3 subpackages: 1, 2, and 3 (to be discovered in that order when rendering)
+//   - kpt.dev/save-on-render-failure: "false" in root Kptfile
+//   - kpt.dev/bfs-rendering: "true" in root Kptfile
+//
+// When:
+//   - subpackage 1 renders OK
+//   - subpackage 2 renders partially, then encounters an error
+//
+// Then:
+//   - no subpackage modifications are preserved
+func (t *PorchSuite) TestNoSaveOnFailureSubpackageRenderHandling() {
+	var (
+		saveOnRenderFailure = kptNoSaveOnRenderFailure
+		renderOrder         = kptBFSRenderOrder
+	)
+	parentPR := t.setupSubpackageRenderingTestScenario(repo, subpackageDir1, subpackageDir2, subpackageDir3)
+
+	parentPR.Annotations = map[string]string{porchPushOnRenderFailure: "true"}
+	t.UpdateF(parentPR)
+	err := t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		// Modify my-subpackage-1's Kptfile to set a label on my-subpackage-1's resources
+		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+			Image: starlarkImage,
+			Selectors: []kptfilev1.Selector{{
+				Kind: kptfilev1.KptFileGVK().Kind,
+				Name: subpackageDir1,
+			}},
+			ConfigMap: map[string]string{
+				"source": `
+subpkgKptfile = ctx.resource_list["items"][0]
+subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test": "modification-1"
+	},
+}])
+				`,
+			},
+		})
+
+		// Modify my-subpackage-2's Kptfile to set a label on my-subpackage-2's resources, then error out and interrupt
+		// the root-plus-subpackages render
+		injectErrorInSubpackageKptfile(subpackageDir2, kptfile)
+
+		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+			Image: starlarkImage,
+			Selectors: []kptfilev1.Selector{{
+				Kind: kptfilev1.KptFileGVK().Kind,
+				Name: subpackageDir3,
+			}},
+			ConfigMap: map[string]string{
+				"source": `
+subpkgKptfile = ctx.resource_list["items"][0]
+subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test": "modification-1"
+	},
+}])
+				`,
+			},
+		})
+	})
+	assert.NoError(t, err)
+
+	var parentPRResources porchapiv1alpha1.PackageRevisionResources
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+
+	// Modify the root Kptfile to save on render failure and to render in BFS order
+	// (this also triggers the render which will encounter the error part-way through)
+	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		maps.Insert(kptfile.Annotations, saveOnRenderFailure)
+		maps.Insert(kptfile.Annotations, renderOrder)
+	})
+	assert.ErrorContains(t, err, "Deliberate error!")
+
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	// no modifications are present
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test-2: modification-2")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+}
+
+// Setup:
+//   - 3 subpackages: 1, 2, and 3 (to be discovered in that order when rendering)
+//   - kpt.dev/save-on-render-failure: "true" in parent package's Kptfile
+//   - kpt.dev/bfs-rendering: "true" in parent package's Kptfile
+//
+// When:
+//   - all subpackages render OK
+//   - parent package renders partially, then encounters an error
+//
+// Then:
+//   - modifications to subpackages are all preserved
+//   - modifications to parent package before the error are preserved
+//   - modifications to parent package after the error are not preserved
+func (t *PorchSuite) TestSaveOnParentFailureSubpackageRenderHandling() {
+	var (
+		saveOnRenderFailure = kptSaveOnRenderFailure
+
+		// BFS render order ensures subpackages are processed BEFORE parent package
+		renderOrder = kptBFSRenderOrder
+	)
+
+	parentPR := t.setupSubpackageRenderingTestScenario(repo, subpackageDir1, subpackageDir2, subpackageDir3)
+
+	parentPR.Annotations = map[string]string{porchPushOnRenderFailure: "true"}
+	t.UpdateF(parentPR)
+	err := t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		for _, subpkg := range []string{subpackageDir1, subpackageDir2, subpackageDir3} {
+			kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+				Image: starlarkImage,
+				Selectors: []kptfilev1.Selector{{
+					Kind: kptfilev1.KptFileGVK().Kind,
+					Name: subpkg,
+				}},
+				ConfigMap: map[string]string{
+					"source": `
+subpkgKptfile = ctx.resource_list["items"][0]
+subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test": "modification-1"
+	},
+}])
+					`,
+				},
+			})
+		}
+		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+			Image: starlarkImage,
+			Selectors: []kptfilev1.Selector{{
+				Kind: kptfilev1.KptFileGVK().Kind,
+				Name: "parent-package",
+			}},
+			ConfigMap: map[string]string{
+				"source": `
+rootKptfile = ctx.resource_list["items"][0]
+rootKptfile.get("pipeline", {}).get("mutators", []).extend([{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test": "modification-1"
+	},
+},{
+	"image": "` + starlarkImage + `",
+	"configMap": {
+		"source": """
+print(\"Deliberate error!\")
+i = 10/0
+"""
+	}
+},{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test-2": "modification-2"
+	},
+}])
+				`,
+			},
+		})
+	})
+	assert.NoError(t, err)
+
+	var parentPRResources porchapiv1alpha1.PackageRevisionResources
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+
+	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		maps.Insert(kptfile.Annotations, saveOnRenderFailure)
+		maps.Insert(kptfile.Annotations, renderOrder)
+	})
+	assert.ErrorContains(t, err, "Deliberate error!")
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	// modifications to subpackages are all present
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1", "my-subpackage-1 does not contain the subpackage-render-test label")
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1", "my-subpackage-2 does not contain the subpackage-render-test label")
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1", "my-subpackage-3 does not contain the subpackage-render-test label")
+
+	// modifications to parent package before the erroring function are present
+	assert.Contains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "subpackage-render-test: modification-1", "parent-package does not contain the subpackage-render-test label")
+	// modifications to parent package after the erroring function are not present
+	assert.NotContains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "subpackage-render-test-2: modification-2", "parent-package contains the subpackage-render-test-2 label")
+}
+
+// Setup:
+//   - 3 subpackages: 1, 2, and 3 (to be discovered in that order when rendering)
+//   - kpt.dev/save-on-render-failure: "false" in parent package's Kptfile
+//   - kpt.dev/bfs-rendering: "false" (DFS render order) in parent package's Kptfile
+//
+// When:
+//   - all subpackages render OK
+//   - parent package renders partially, then encounters an error
+//
+// Then:
+//   - no subpackage modifications are preserved
+//   - no parent package modifications are preserved
+func (t *PorchSuite) TestNoSaveOnParentFailureSubpackageRenderHandling() {
+	var (
+		saveOnRenderFailure = kptNoSaveOnRenderFailure
+
+		// DFS render order ensures parent package is processed BEFORE subpackages
+		renderOrder = kptDFSRenderOrder
+	)
+	parentPR := t.setupSubpackageRenderingTestScenario(repo, subpackageDir1, subpackageDir2, subpackageDir3)
+
+	err := t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		for _, subpkg := range []string{subpackageDir1, subpackageDir2, subpackageDir3} {
+			kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+				Image: starlarkImage,
+				Selectors: []kptfilev1.Selector{{
+					Kind: kptfilev1.KptFileGVK().Kind,
+					Name: subpkg,
+				}},
+				ConfigMap: map[string]string{
+					"source": `
+subpkgKptfile = ctx.resource_list["items"][0]
+subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test": "modification-1"
+	},
+}])
+					`,
+				},
+			})
+		}
+		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+			Image: starlarkImage,
+			Selectors: []kptfilev1.Selector{{
+				Kind: kptfilev1.KptFileGVK().Kind,
+				Name: "parent-package",
+			}},
+			ConfigMap: map[string]string{
+				"source": `
+rootKptfile = ctx.resource_list["items"][0]
+rootKptfile.get("pipeline", {}).get("mutators", []).extend([{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test": "modification-1"
+	},
+},{
+	"image": "` + starlarkImage + `",
+	"configMap": {
+		"source": """
+print(\"Deliberate error!\")
+i = 10/0
+"""
+	}
+},{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test": "modification-2"
+	},
+}])
+				`,
+			},
+		})
+	})
+	assert.NoError(t, err)
+
+	var parentPRResources porchapiv1alpha1.PackageRevisionResources
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+
+	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		maps.Insert(kptfile.Annotations, saveOnRenderFailure)
+		maps.Insert(kptfile.Annotations, renderOrder)
+	})
+	assert.ErrorContains(t, err, "Deliberate error!")
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	// no modifications are present
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir2+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources[subpackageDir3+"/my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "subpackage-render-test: modification-1")
+	assert.NotContains(t, parentPRResources.Spec.Resources["my-configmap.yaml"], "subpackage-render-test: modification-2")
+}
+
+// Setup:
+//   - 1 subpackage with a timestamp-setting mutator in its pipeline
+//   - parent package, also with a timestamp-setting mutator in its pipeline
+//
+// When: rendering is triggered first without explicit order (default DFS)
+// Then: parent is rendered AFTER subpackage
+//
+// When: rendering is then triggered with kpt.dev/bfs-rendering: "true"
+// Then: parent is rendered BEFORE subpackage
+func (t *PorchSuite) TestBreadthFirstOrderSubpackageRenderHandling() {
+	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repo, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
+
+	cloneePR1V1 := t.createPR(repo, cloneePackageName+"-1", clonedWorkspaceV1)
+	err := t.UpdateKptfileF(cloneePR1V1, func(kptfile *kptfilev1.KptFile) {
+		// Set subpackage's render order to BFS
+		maps.Insert(kptfile.Annotations, kptBFSRenderOrder)
+
+		// Add a script in subpackage to set a timestamp and track time of render
+		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+			Image: starlarkImage,
+			Selectors: []kptfilev1.Selector{{
+				Kind: "ConfigMap",
+			}},
+			ConfigMap: map[string]string{
+				"source": `
+load('time.star', 'time')
+file = ctx.resource_list["items"][0]
+file.get("metadata", {}).get("labels", {})["subpackage-render-test-timestamp"] = time.now()
+				`,
+			},
+		})
+	})
+	require.NoError(t.T(), err)
+	t.approvePR(cloneePR1V1)
+
+	parentPR := t.createPR(repo, parentPackageName, parentWorkspace)
+
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePR1V1, subpackageDir1)
+	assert.NoError(t, err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR1V1, parentPR, subpackageDir1, err)
+
+	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		// Add a script in parent package to set a timestamp and track time of render
+		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+			Image: starlarkImage,
+			Selectors: []kptfilev1.Selector{{
+				Kind: "ConfigMap",
+				Name: "my-subpkg-file-operations.parent-package.parent-workspace-configmap",
+			}},
+			ConfigMap: map[string]string{
+				"source": `
+load('time.star', 'time')
+file = ctx.resource_list["items"][0]
+file.get("metadata", {}).get("labels", {})["subpackage-render-test-timestamp"] = time.now()
+				`,
+			},
+		})
+	})
+	require.NoError(t.T(), err)
+
+	// Insert a meaningless annotation in parent package's Kptfile to trigger a render
+	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		maps.Insert(kptfile.Annotations, maps.All(map[string]string{"something": "some-value"}))
+	})
+	require.NoError(t.T(), err)
+
+	var parentPRResources porchapiv1alpha1.PackageRevisionResources
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+	parentRenderTime := t.extractRenderTimestamp(parentPRResources, "my-configmap.yaml")
+	subpackageRenderTime := t.extractRenderTimestamp(parentPRResources, subpackageDir1+"/my-configmap.yaml")
+
+	// Greater parent render time shows that parent was rendered AFTER subpackage,
+	// showing that BFS annotation in subpackage had no effect in render done through
+	// parent package.
+	// (also showing that DFS rendering is default)
+	assert.Greater(t, parentRenderTime, subpackageRenderTime)
+
+	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		maps.Insert(kptfile.Annotations, kptBFSRenderOrder)
+	})
+	require.NoError(t.T(), err)
+
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+	parentRenderTime = t.extractRenderTimestamp(parentPRResources, "my-configmap.yaml")
+	subpackageRenderTime = t.extractRenderTimestamp(parentPRResources, subpackageDir1+"/my-configmap.yaml")
+
+	// Lesser parent render time shows that parent was rendered BEFORE subpackage
+	assert.Less(t, parentRenderTime, subpackageRenderTime)
+}
+
+// Setup:
+//   - 1 subpackage with a timestamp-setting mutator in its pipeline
+//   - parent package, also with a timestamp-setting mutator in its pipeline
+//
+// When: rendering is triggered first without explicit order (default DFS)
+// Then: parent is rendered AFTER subpackage
+//
+// When: rendering is then triggered with kpt.dev/bfs-rendering: "false" (explicit DFS)
+// Then: parent is still rendered AFTER subpackage
+func (t *PorchSuite) TestDepthFirstOrderSubpackageRenderHandling() {
+	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repo, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
+
+	cloneePR1V1 := t.createPR(repo, cloneePackageName+"-1", clonedWorkspaceV1)
+	err := t.UpdateKptfileF(cloneePR1V1, func(kptfile *kptfilev1.KptFile) {
+		// Set subpackage's render order to DFS
+		maps.Insert(kptfile.Annotations, kptDFSRenderOrder)
+
+		// Add a script in subpackage to set a timestamp and track time of render
+		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+			Image: starlarkImage,
+			Selectors: []kptfilev1.Selector{{
+				Kind: "ConfigMap",
+			}},
+			ConfigMap: map[string]string{
+				"source": `
+load('time.star', 'time')
+file = ctx.resource_list["items"][0]
+file.get("metadata", {}).get("labels", {})["subpackage-render-test-timestamp"] = time.now()
+				`,
+			},
+		})
+	})
+	require.NoError(t.T(), err)
+	t.approvePR(cloneePR1V1)
+
+	parentPR := t.createPR(repo, parentPackageName, parentWorkspace)
+
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePR1V1, subpackageDir1)
+	assert.NoError(t, err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR1V1, parentPR, subpackageDir1, err)
+
+	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		// Add a script in parent package to set a timestamp and track time of render
+		kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+			Image: starlarkImage,
+			Selectors: []kptfilev1.Selector{{
+				Kind: "ConfigMap",
+				Name: "my-subpkg-file-operations.parent-package.parent-workspace-configmap",
+			}},
+			ConfigMap: map[string]string{
+				"source": `
+load('time.star', 'time')
+file = ctx.resource_list["items"][0]
+file.get("metadata", {}).get("labels", {})["subpackage-render-test-timestamp"] = time.now()
+				`,
+			},
+		})
+	})
+	require.NoError(t.T(), err)
+
+	// Insert a meaningless annotation in parent package's Kptfile to trigger a render
+	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		maps.Insert(kptfile.Annotations, maps.All(map[string]string{"something": "some-value"}))
+	})
+	require.NoError(t.T(), err)
+
+	var parentPRResources porchapiv1alpha1.PackageRevisionResources
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+	parentRenderTime := t.extractRenderTimestamp(parentPRResources, "my-configmap.yaml")
+	subpackageRenderTime := t.extractRenderTimestamp(parentPRResources, subpackageDir1+"/my-configmap.yaml")
+
+	// Greater parent render time shows that parent was rendered AFTER subpackage,
+	// showing that BFS annotation in subpackage had no effect in render done through
+	// parent package.
+	// (also showing that DFS rendering is default)
+	assert.Greater(t, parentRenderTime, subpackageRenderTime)
+
+	err = t.UpdateKptfileF(parentPR, func(kptfile *kptfilev1.KptFile) {
+		maps.Insert(kptfile.Annotations, kptDFSRenderOrder)
+	})
+	require.NoError(t.T(), err)
+
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+	parentRenderTime = t.extractRenderTimestamp(parentPRResources, "my-configmap.yaml")
+	subpackageRenderTime = t.extractRenderTimestamp(parentPRResources, subpackageDir1+"/my-configmap.yaml")
+
+	// Greater parent render time shows that parent was rendered AFTER subpackage
+	assert.Greater(t, parentRenderTime, subpackageRenderTime)
+}
+
+func (t *PorchSuite) setupSubpackageRenderingTestScenario(repo string, subpackageDir1 string, subpackageDir2 string, subpackageDir3 string) *porchapiv1alpha1.PackageRevision {
+	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repo, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
+
+	cloneePR1V1 := t.createPR(repo, cloneePackageName+"-1", clonedWorkspaceV1)
+	t.approvePR(cloneePR1V1)
+
+	cloneePR2V1 := t.createPR(repo, cloneePackageName+"-2", clonedWorkspaceV1)
+	t.approvePR(cloneePR2V1)
+
+	cloneePR3V1 := t.createPR(repo, cloneePackageName+"-3", clonedWorkspaceV1)
+	t.approvePR(cloneePR3V1)
+
+	parentPR := t.createPR(repo, parentPackageName, parentWorkspace)
+
+	parentPR, err := t.cloneSubpackage(parentPR, cloneePR1V1, subpackageDir1)
+	require.NoError(t.T(), err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR1V1, parentPR, subpackageDir1, err)
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePR2V1, subpackageDir2)
+	require.NoError(t.T(), err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR2V1, parentPR, subpackageDir2, err)
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePR3V1, subpackageDir3)
+	require.NoError(t.T(), err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR3V1, parentPR, subpackageDir3, err)
+	return parentPR
+}
+
+func injectErrorInSubpackageKptfile(subpackageDir string, kptfile *kptfilev1.KptFile) {
+	kptfile.Pipeline.Mutators = append(kptfile.Pipeline.Mutators, kptfilev1.Function{
+		Image: starlarkImage,
+		Selectors: []kptfilev1.Selector{{
+			Kind: kptfilev1.KptFileGVK().Kind,
+			Name: subpackageDir,
+		}},
+		ConfigMap: map[string]string{
+			"source": `
+subpkgKptfile = ctx.resource_list["items"][0]
+subpkgKptfile.get("pipeline", {}).get("mutators", []).extend([{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test": "modification-1"
+	},
+},{
+	"image": "` + starlarkImage + `",
+	"configMap": {
+		"source": """
+print(\"Deliberate error!\")
+i = 10/0
+"""
+	}
+},{
+	"image": "` + setLabelsImage + `",
+	"configMap": {
+		"subpackage-render-test-2": "modification-2"
+	},
+}])
+			`,
+		},
+	})
+}
+
+func (t *PorchSuite) extractRenderTimestamp(resources porchapiv1alpha1.PackageRevisionResources, resourcePath string) time.Time {
+	t.T().Helper()
+	resourceRawString := resources.Spec.Resources[resourcePath]
+	r, err := yaml.Parse(resourceRawString)
+	require.NoError(t.T(), err)
+	renderTimestamp, err := r.GetFieldValue("metadata.labels.subpackage-render-test-timestamp")
+	require.NoError(t.T(), err)
+	renderTime, err := time.Parse(time.RFC3339, renderTimestamp.(string))
+	require.NoError(t.T(), err)
+	return renderTime
+}

--- a/test/e2e/api/rpkg_subpkg_test.go
+++ b/test/e2e/api/rpkg_subpkg_test.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"fmt"
+	"maps"
 	"strings"
 
 	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
@@ -22,6 +24,7 @@ import (
 	porchapiv1alpha1 "github.com/kptdev/porch/api/porch/v1alpha1"
 	suiteutils "github.com/kptdev/porch/test/e2e/suiteutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -55,9 +58,11 @@ func (t *PorchSuite) TestSubpackageCloneIntoRoot() {
 
 	parentPR := t.createPR(repo, parentPackageName, parentWorkspace)
 	parentPR, err := t.cloneSubpackage(parentPR, parentPR, "")
-	if err == nil || !strings.Contains(err.Error(), "subpackage directory") && !strings.Contains(err.Error(), "is invalid") {
-		t.Fatalf("Clone of subpackage onto root gave an unexpected error %v", err)
-	}
+
+	assert.Error(t.T(), err, "Clone of subpackage into root should have given an error")
+	assert.Condition(t.T(), func() bool {
+		return strings.Contains(err.Error(), "subpackage directory") || strings.Contains(err.Error(), "is invalid")
+	}, "Clone of subpackage into root gave an unexpected error %v", err)
 
 	t.deletePR(parentPR)
 }
@@ -78,9 +83,7 @@ func (t *PorchSuite) TestSubpackageCloneIntoExisting() {
 	parentPR := t.createPR(repo, parentPackageName, parentWorkspace)
 
 	parentPR, err := t.cloneSubpackage(parentPR, cloneePRV1, subpackageDir1)
-	if err != nil {
-		t.Fatalf("Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir1, err)
-	}
+	require.NoErrorf(t.T(), err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePRV1, parentPR, subpackageDir1, err)
 
 	var parentPRResources porchapiv1alpha1.PackageRevisionResources
 	t.GetF(client.ObjectKey{
@@ -366,6 +369,142 @@ func (t *PorchSuite) TestSubpackageCloneAndUpgradeNonOverlapping() {
 	t.deletePR(cloneePR4V3)
 	t.deletePR(cloneePR4V2)
 	t.deletePR(cloneePR4V1)
+}
+
+func (t *PorchSuite) TestSubpackageModifyRenameAndRemove() {
+	const (
+		repo           = "subpkg-file-operations"
+		subpackageDir1 = "my-subpackage-1"
+		subpackageDir2 = "my-subpackage-2"
+		subpackageDir3 = "my-subpackage-3"
+
+		newLabel         = "test-subpkg-content-modify"
+		renamedSubpkgDir = "test-rename-subpkg"
+	)
+	t.RegisterGitRepositoryF(t.GetPorchTestRepoURL(), repo, "", suiteutils.GiteaUser, suiteutils.GiteaPassword)
+
+	cloneePR1V1 := t.createPR(repo, cloneePackageName+"-1", clonedWorkspaceV1)
+	t.approvePR(cloneePR1V1)
+
+	cloneePR1V2 := t.copyPR(repo, cloneePR1V1, clonedWorkspaceV2)
+	t.approvePR(cloneePR1V2)
+
+	cloneePR2V1 := t.createPR(repo, cloneePackageName+"-2", clonedWorkspaceV1)
+	t.approvePR(cloneePR2V1)
+
+	cloneePR2V2 := t.copyPR(repo, cloneePR2V1, clonedWorkspaceV2)
+	t.approvePR(cloneePR2V2)
+
+	cloneePR3V1 := t.createPR(repo, cloneePackageName+"-3", clonedWorkspaceV1)
+	t.approvePR(cloneePR3V1)
+
+	cloneePR3V2 := t.copyPR(repo, cloneePR3V1, clonedWorkspaceV2)
+	t.approvePR(cloneePR3V2)
+
+	parentPR := t.createPR(repo, parentPackageName, parentWorkspace)
+
+	parentPR, err := t.cloneSubpackage(parentPR, cloneePR1V1, subpackageDir1)
+	assert.NoError(t, err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR1V1, parentPR, subpackageDir1, err)
+
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePR2V1, subpackageDir2)
+	assert.NoError(t, err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR2V1, parentPR, subpackageDir2, err)
+
+	var parentPRResources porchapiv1alpha1.PackageRevisionResources
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	// Modify files in my-subpackage-1
+	parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"] = strings.ReplaceAll(
+		parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"],
+		clonedWorkspaceV1, newLabel)
+	parentPRResources.Spec.Resources[subpackageDir1+"/README.md.bak"] = parentPRResources.Spec.Resources[subpackageDir1+"/README.md"]
+	delete(parentPRResources.Spec.Resources, subpackageDir1+"/README.md")
+
+	// Rename my-subpackage-2
+	maps.DeleteFunc(parentPRResources.Spec.Resources, func(k, v string) bool {
+		if strings.HasPrefix(k, subpackageDir2) {
+			parentPRResources.Spec.Resources[strings.ReplaceAll(k, subpackageDir2, renamedSubpkgDir)] = v
+			return true
+		}
+		return false
+	})
+
+	// Remove my-subpackage-3
+	maps.DeleteFunc(parentPRResources.Spec.Resources, func(k, v string) bool {
+		return strings.HasPrefix(k, subpackageDir3)
+	})
+
+	t.UpdateF(&parentPRResources)
+
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	// Check modifications were saved in my-subpackage-1
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"],
+		"test-label-"+newLabel+": "+newLabel)
+	assert.Contains(t, parentPRResources.Spec.Resources, subpackageDir1+"/README.md.bak")
+	assert.NotContains(t, parentPRResources.Spec.Resources, subpackageDir1+"/README.md")
+
+	// Check my-subpackage-2 is now test-rename-subpkg
+	assert.NotContains(t, parentPRResources.Spec.Resources, subpackageDir2+"/Kptfile")
+	assert.NotContains(t, parentPRResources.Spec.Resources, subpackageDir2+"/my-configmap.yaml")
+	assert.NotContains(t, parentPRResources.Spec.Resources, subpackageDir2+"/README.md")
+	assert.Contains(t, parentPRResources.Spec.Resources, renamedSubpkgDir+"/Kptfile")
+	assert.Contains(t, parentPRResources.Spec.Resources, renamedSubpkgDir+"/my-configmap.yaml")
+	assert.Contains(t, parentPRResources.Spec.Resources, renamedSubpkgDir+"/README.md")
+
+	// Check my-subpackage-3 is removed
+	assert.NotContains(t, parentPRResources.Spec.Resources, subpackageDir3+"/Kptfile")
+	assert.NotContains(t, parentPRResources.Spec.Resources, subpackageDir3+"/my-configmap.yaml")
+	assert.NotContains(t, parentPRResources.Spec.Resources, subpackageDir3+"/README.md")
+
+	// Check upgrades succeed and fail as expected
+	parentPR.ResourceVersion = parentPRResources.ResourceVersion
+	parentPR, err = t.upgradeSubpackage(parentPR, cloneePR1V1, cloneePR1V2, subpackageDir1)
+	assert.NoError(t, err)
+	parentPR, err = t.upgradeSubpackage(parentPR, cloneePR2V1, cloneePR2V2, subpackageDir2)
+	assert.ErrorContains(t, err, fmt.Sprintf("subpackage \"%s\" not found in package", subpackageDir2))
+	parentPR.Spec.Tasks = parentPR.Spec.Tasks[:len(parentPR.Spec.Tasks)-1]
+	parentPR, err = t.upgradeSubpackage(parentPR, cloneePR2V1, cloneePR2V2, renamedSubpkgDir)
+	assert.NoError(t, err)
+	parentPR, err = t.upgradeSubpackage(parentPR, cloneePR3V1, cloneePR3V2, subpackageDir3)
+	assert.ErrorContains(t, err, fmt.Sprintf("subpackage \"%s\" not found in package", subpackageDir3))
+
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      parentPR.Name,
+	}, &parentPRResources)
+
+	// Check modifications to my-subpackage-1 persisted through the upgrade
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"],
+		"test-label-"+newLabel+": "+newLabel)
+	assert.Contains(t, parentPRResources.Spec.Resources, subpackageDir1+"/README.md.bak")
+	// Check previous state of my-subpackage-1 was merged in by the upgrade
+	assert.Contains(t, parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"],
+		"test-label-"+cloneePR1V1.Spec.WorkspaceName+": "+cloneePR1V1.Spec.WorkspaceName)
+	assert.Contains(t, parentPRResources.Spec.Resources, subpackageDir1+"/README.md")
+
+	// Check the renamed subpackage persisted through the upgrade
+	assert.Contains(t, parentPRResources.Spec.Resources, renamedSubpkgDir+"/Kptfile")
+	assert.Contains(t, parentPRResources.Spec.Resources, renamedSubpkgDir+"/my-configmap.yaml")
+	assert.Contains(t, parentPRResources.Spec.Resources, renamedSubpkgDir+"/README.md")
+
+	// Check my-subpackage-3 is still gone
+	assert.NotContains(t, parentPRResources.Spec.Resources, subpackageDir3+"/Kptfile")
+	assert.NotContains(t, parentPRResources.Spec.Resources, subpackageDir3+"/my-configmap.yaml")
+	assert.NotContains(t, parentPRResources.Spec.Resources, subpackageDir3+"/README.md")
+
+	t.deletePR(parentPR)
+	t.deletePR(cloneePR1V2)
+	t.deletePR(cloneePR1V1)
+	t.deletePR(cloneePR2V2)
+	t.deletePR(cloneePR2V1)
+	t.deletePR(cloneePR3V2)
+	t.deletePR(cloneePR3V1)
 }
 
 func (t *PorchSuite) SimpleSubpackageCloneAndUpgradeScenario(subpackageRepo, subpackageDir string) {

--- a/test/e2e/api/rpkg_subpkg_test.go
+++ b/test/e2e/api/rpkg_subpkg_test.go
@@ -59,7 +59,7 @@ func (t *PorchSuite) TestSubpackageCloneIntoRoot() {
 	parentPR := t.createPR(repo, parentPackageName, parentWorkspace)
 	parentPR, err := t.cloneSubpackage(parentPR, parentPR, "")
 
-	assert.Error(t.T(), err, "Clone of subpackage into root should have given an error")
+	require.Error(t.T(), err, "Clone of subpackage into root should have given an error")
 	assert.Condition(t.T(), func() bool {
 		return strings.Contains(err.Error(), "subpackage directory") || strings.Contains(err.Error(), "is invalid")
 	}, "Clone of subpackage into root gave an unexpected error %v", err)
@@ -404,16 +404,22 @@ func (t *PorchSuite) TestSubpackageModifyRenameAndRemove() {
 	parentPR := t.createPR(repo, parentPackageName, parentWorkspace)
 
 	parentPR, err := t.cloneSubpackage(parentPR, cloneePR1V1, subpackageDir1)
-	assert.NoError(t, err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR1V1, parentPR, subpackageDir1, err)
+	require.NoError(t.T(), err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR1V1, parentPR, subpackageDir1, err)
 
 	parentPR, err = t.cloneSubpackage(parentPR, cloneePR2V1, subpackageDir2)
-	assert.NoError(t, err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR2V1, parentPR, subpackageDir2, err)
+	require.NoError(t.T(), err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR2V1, parentPR, subpackageDir2, err)
+
+	parentPR, err = t.cloneSubpackage(parentPR, cloneePR3V1, subpackageDir3)
+	require.NoError(t.T(), err, "Clone of subpackage %v into parent PR %v subpackage directory %q failed: %v", cloneePR3V1, parentPR, subpackageDir3, err)
 
 	var parentPRResources porchapiv1alpha1.PackageRevisionResources
 	t.GetF(client.ObjectKey{
 		Namespace: t.Namespace,
 		Name:      parentPR.Name,
 	}, &parentPRResources)
+	require.Contains(t.T(), parentPRResources.Spec.Resources, subpackageDir1+"/Kptfile")
+	require.Contains(t.T(), parentPRResources.Spec.Resources, subpackageDir2+"/Kptfile")
+	require.Contains(t.T(), parentPRResources.Spec.Resources, subpackageDir3+"/Kptfile")
 
 	// Modify files in my-subpackage-1
 	parentPRResources.Spec.Resources[subpackageDir1+"/my-configmap.yaml"] = strings.ReplaceAll(
@@ -424,8 +430,8 @@ func (t *PorchSuite) TestSubpackageModifyRenameAndRemove() {
 
 	// Rename my-subpackage-2
 	maps.DeleteFunc(parentPRResources.Spec.Resources, func(k, v string) bool {
-		if strings.HasPrefix(k, subpackageDir2) {
-			parentPRResources.Spec.Resources[strings.ReplaceAll(k, subpackageDir2, renamedSubpkgDir)] = v
+		if after, ok := strings.CutPrefix(k, subpackageDir2); ok {
+			parentPRResources.Spec.Resources[renamedSubpkgDir+after] = v
 			return true
 		}
 		return false

--- a/test/e2e/suiteutils/suite.go
+++ b/test/e2e/suiteutils/suite.go
@@ -541,7 +541,7 @@ func (t *TestSuite) ParseKptfileF(resources *porchapi.PackageRevisionResources) 
 	return kptfile
 }
 
-func (t *TestSuite) UpdateKptfileF(pr *porchapi.PackageRevision, edits func(*kptfilev1.KptFile)) error {
+func (t *TestSuite) UpdateKptfile(pr *porchapi.PackageRevision, edits func(*kptfilev1.KptFile)) error {
 	t.T().Helper()
 	var prr porchapi.PackageRevisionResources
 	t.GetF(client.ObjectKey{
@@ -550,7 +550,16 @@ func (t *TestSuite) UpdateKptfileF(pr *porchapi.PackageRevision, edits func(*kpt
 	}, &prr)
 
 	kptfile := t.ParseKptfileF(&prr)
+
+	annotationsWasNil := kptfile.Annotations == nil
+	if annotationsWasNil {
+		kptfile.Annotations = make(map[string]string)
+	}
 	edits(kptfile)
+	if annotationsWasNil && len(kptfile.Annotations) == 0 {
+		kptfile.Annotations = nil
+	}
+
 	t.SaveKptfileF(&prr, kptfile)
 
 	t.Logf("updating Kptfile in PackageRevisionResources %v", DebugFormat(&prr))

--- a/test/e2e/suiteutils/suite.go
+++ b/test/e2e/suiteutils/suite.go
@@ -541,6 +541,28 @@ func (t *TestSuite) ParseKptfileF(resources *porchapi.PackageRevisionResources) 
 	return kptfile
 }
 
+func (t *TestSuite) UpdateKptfileF(pr *porchapi.PackageRevision, edits func(*kptfilev1.KptFile)) error {
+	t.T().Helper()
+	var prr porchapi.PackageRevisionResources
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      pr.Name,
+	}, &prr)
+
+	kptfile := t.ParseKptfileF(&prr)
+	edits(kptfile)
+	t.SaveKptfileF(&prr, kptfile)
+
+	t.Logf("updating Kptfile in PackageRevisionResources %v", DebugFormat(&prr))
+
+	err := t.Client.Update(t.GetContext(), &prr)
+	t.GetF(client.ObjectKey{
+		Namespace: t.Namespace,
+		Name:      pr.Name,
+	}, pr)
+	return err
+}
+
 func (t *TestSuite) SaveKptfileF(resources *porchapi.PackageRevisionResources, kptfile *kptfilev1.KptFile) {
 	t.T().Helper()
 	b, err := yaml.MarshalWithOptions(kptfile, &yaml.EncoderOptions{SeqIndent: yaml.WideSequenceStyle})


### PR DESCRIPTION
## Description
<!-- Describe what this PR does and why -->
- What changed:
  - New `TestSubpackageModifyRenameAndRemove` test covering subpackage resource modification, directory renaming, and subpackage deletion.
  - New E2E test file `rpkg_subpkg_render_test.go` with rendering-related tests covering BFS/DFS render orders, save-on-render-failure behaviour, and behaviour when pipelines encounter error partway through.
  - New `UpdateKptfileF` helper in the test suite, allowing updates to a PackageRevision's Kptfile while abstracting away getting PackageRevisionResources, pushing them back to Porch, etc.
  - Improved some existing test assertions to use testify (`assert`/`require`) instead of raw `Fatalf` calls.
- Why it's needed: Adding E2E test coverage for subpackage file-level operations (modify, rename, remove) and rendering interactions between subpackages and parent packages under different ordering and failure-handling configurations.
- How it works:
  - The rendering tests:
    - set up parent packages with subpackages
    - inject deliberate errors via starlark functions in pipelines
    - verify that partial render results are preserved (or discarded) according to the `kpt.dev/save-on-render-failure` and `kpt.dev/bfs-rendering` annotations.
  - The BFS/DFS tests inject timestamp generation code into parent and subpackage pipelines and extract the resulting timestamps to verify render ordering.
  - The modify/rename/remove test manipulates `PackageRevisionResources` directly and verifies that changes persist through subsequent upgrade operations.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- N/A

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [ ] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. Deploy Porch to a kind cluster or set KUBECONFIG to the kube-config file for an existing test environment.
2. From Porch repo root, run tests: `make test-e2e`

---

## Additional Notes (Optional)
- Known issues: 
- Further improvements: 
- Review notes: 

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro/Amazon Q to:
    - generate the pull request description from the commit message
    - generate some of the Setup/When/Then comments on test methods in `rpkg_subpkg_render_test.go`