### PR TITLE
Fixed CLI Compatibility Matrix runs

### DIFF
--- a/.github/workflows/porch-compat-matrix.yaml
+++ b/.github/workflows/porch-compat-matrix.yaml
@@ -16,7 +16,6 @@ name: CLI Compatibility Matrix
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     - cron: "0 8 * * 1" # Every Monday at 8AM UTC
 

--- a/.github/workflows/porch-compat-matrix.yaml
+++ b/.github/workflows/porch-compat-matrix.yaml
@@ -138,12 +138,12 @@ jobs:
 
       # --- Step 4: Build and deploy porch with DB cache ---
 
-      - name: Build and deploy porch (DB cache, no git server)
+      - name: Build and deploy porch (DB cache, push drafts)
         run: |
           echo "=============================================="
           echo "[DEPLOY] Building and deploying porch server ${{ matrix.server_version }} with DB cache"
           echo "=============================================="
-          make run-in-kind-db-cache-no-git
+          make run-in-kind-db-cache-push-drafts
 
       # --- Step 5: Download the CLI binaries ---
 

--- a/.github/workflows/porch-compat-matrix.yaml
+++ b/.github/workflows/porch-compat-matrix.yaml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # 1. Resolve the last 4 published releases and build the server matrix
+  # 1. Resolve the last 2 published releases + latest and build the server matrix
   # ---------------------------------------------------------------------------
   resolve-versions:
     name: Resolve Versions
@@ -192,7 +192,7 @@ jobs:
           FAILED_TESTS=""
           if [ $TEST_EXIT -ne 0 ]; then
             RESULT="fail"
-            FAILED_TESTS=$(grep -E '^\s*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
+            FAILED_TESTS=$(grep -E '^[[:space:]]*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
           fi
 
           cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON
@@ -225,7 +225,7 @@ jobs:
           FAILED_TESTS=""
           if [ $TEST_EXIT -ne 0 ]; then
             RESULT="fail"
-            FAILED_TESTS=$(grep -E '^\s*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
+            FAILED_TESTS=$(grep -E '^[[:space:]]*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
           fi
 
           cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON
@@ -258,7 +258,7 @@ jobs:
           FAILED_TESTS=""
           if [ $TEST_EXIT -ne 0 ]; then
             RESULT="fail"
-            FAILED_TESTS=$(grep -E '^\s*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
+            FAILED_TESTS=$(grep -E '^[[:space:]]*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
           fi
 
           cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON

--- a/.github/workflows/porch-compat-matrix.yaml
+++ b/.github/workflows/porch-compat-matrix.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # Always query upstream repo for releases (works correctly from forks)
           VERSIONS=$(gh api repos/${UPSTREAM_REPO}/releases \
-            --jq '[.[] | select(.draft == false)] | sort_by(.published_at) | reverse | .[0:4] | [.[].tag_name]')
+            --jq '[.[] | select(.draft == false) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(.published_at) | reverse | .[0:2] | [.[].tag_name]')
           echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
           echo "Resolved releases: ${VERSIONS}"
 
@@ -76,12 +76,12 @@ jobs:
     steps:
       # --- Step 1: Checkout the server version's source code ---
 
-      - name: Checkout upstream latest (1.5 branch)
+      - name: Checkout upstream latest (main branch)
         if: matrix.server_version == 'latest'
         uses: actions/checkout@v4
         with:
           repository: kptdev/porch
-          ref: '1.5' # NOTE this should revert back to main when we merge back
+          ref: main
 
       - name: Checkout upstream tag ${{ matrix.server_version }}
         if: matrix.server_version != 'latest'
@@ -168,42 +168,34 @@ jobs:
             echo "  ${VERSION}: $("${d}porchctl" version 2>/dev/null || echo 'version check skipped')"
           done
 
-      # --- Step 6: Run CLI tests with each porchctl version sequentially ---
+      # --- Step 6: Prepare results directory ---
 
-      - name: Run CLI tests with all porchctl versions
-        id: run-tests
+      - name: Prepare compat results directory
+        run: mkdir -p .build/compat-results
+
+      # --- Step 6.1: Run CLI tests - porchctl latest ---
+
+      - name: "porch-server ${{ matrix.server_version }} vs porchctl latest CLI Test"
+        id: test-cli-latest
         run: |
           set +e
-          mkdir -p .build/compat-results
+          CLI_VERSION="latest"
+          cp "${GITHUB_WORKSPACE}/.build/cli/${CLI_VERSION}/porchctl" "${GITHUB_WORKSPACE}/.build/porchctl"
+          echo "Using porchctl from ${CLI_VERSION}:"
+          .build/porchctl version 2>/dev/null || echo "version check skipped"
 
-          CLI_VERSIONS="latest $(echo "$RELEASES" | jq -r '.[]')"
+          LOG_FILE=".build/compat-results/test-${CLI_VERSION}.log"
+          E2E=1 go test -v -timeout 20m ./test/e2e/cli 2>&1 | tee "${LOG_FILE}"
+          TEST_EXIT=${PIPESTATUS[0]}
 
-          for CLI_VERSION in $CLI_VERSIONS; do
-            echo ""
-            echo "=============================================="
-            echo "[TEST] CLI ${CLI_VERSION} against server ${{ matrix.server_version }}"
-            echo "=============================================="
+          RESULT="pass"
+          FAILED_TESTS=""
+          if [ $TEST_EXIT -ne 0 ]; then
+            RESULT="fail"
+            FAILED_TESTS=$(grep -E '^\s*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
+          fi
 
-            # Swap the porchctl binary
-            cp "${GITHUB_WORKSPACE}/.build/cli/${CLI_VERSION}/porchctl" "${GITHUB_WORKSPACE}/.build/porchctl"
-            echo "[TEST] Using porchctl from ${CLI_VERSION}:"
-            .build/porchctl version 2>/dev/null || echo "  version check skipped"
-
-            LOG_FILE=".build/compat-results/test-${CLI_VERSION}.log"
-
-            E2E=1 go test -v -timeout 20m ./test/e2e/cli 2>&1 | tee "${LOG_FILE}"
-            TEST_EXIT=${PIPESTATUS[0]}
-
-            # Parse results
-            RESULT="pass"
-            FAILED_TESTS=""
-            if [ $TEST_EXIT -ne 0 ]; then
-              RESULT="fail"
-              FAILED_TESTS=$(grep -E '^\s*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
-            fi
-
-            # Write result JSON
-            cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON
+          cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON
           {
             "server_version": "${{ matrix.server_version }}",
             "cli_version": "${CLI_VERSION}",
@@ -212,10 +204,73 @@ jobs:
             "failed_tests": "${FAILED_TESTS}"
           }
           EOJSON
+          echo "Result: ${RESULT} | Failed tests: ${FAILED_TESTS}"
 
-            echo "Result: ${RESULT}"
-            echo "Failed tests: ${FAILED_TESTS}"
-          done
+      # --- Step 6.2: Run CLI tests - porchctl n-1 ---
+
+      - name: "porch-server ${{ matrix.server_version }} vs porchctl ${{ fromJson(needs.resolve-versions.outputs.releases)[0] }} CLI Test"
+        id: test-cli-n1
+        run: |
+          set +e
+          CLI_VERSION=$(echo "$RELEASES" | jq -r '.[0]')
+          cp "${GITHUB_WORKSPACE}/.build/cli/${CLI_VERSION}/porchctl" "${GITHUB_WORKSPACE}/.build/porchctl"
+          echo "Using porchctl from ${CLI_VERSION}:"
+          .build/porchctl version 2>/dev/null || echo "version check skipped"
+
+          LOG_FILE=".build/compat-results/test-${CLI_VERSION}.log"
+          E2E=1 go test -v -timeout 20m ./test/e2e/cli 2>&1 | tee "${LOG_FILE}"
+          TEST_EXIT=${PIPESTATUS[0]}
+
+          RESULT="pass"
+          FAILED_TESTS=""
+          if [ $TEST_EXIT -ne 0 ]; then
+            RESULT="fail"
+            FAILED_TESTS=$(grep -E '^\s*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
+          fi
+
+          cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON
+          {
+            "server_version": "${{ matrix.server_version }}",
+            "cli_version": "${CLI_VERSION}",
+            "kpt_version": "$(cat .build/kpt-version.txt 2>/dev/null || echo 'unknown')",
+            "result": "${RESULT}",
+            "failed_tests": "${FAILED_TESTS}"
+          }
+          EOJSON
+          echo "Result: ${RESULT} | Failed tests: ${FAILED_TESTS}"
+
+      # --- Step 6.3: Run CLI tests - porchctl n-2 ---
+
+      - name: "porch-server ${{ matrix.server_version }} vs porchctl ${{ fromJson(needs.resolve-versions.outputs.releases)[1] }} CLI Test"
+        id: test-cli-n2
+        run: |
+          set +e
+          CLI_VERSION=$(echo "$RELEASES" | jq -r '.[1]')
+          cp "${GITHUB_WORKSPACE}/.build/cli/${CLI_VERSION}/porchctl" "${GITHUB_WORKSPACE}/.build/porchctl"
+          echo "Using porchctl from ${CLI_VERSION}:"
+          .build/porchctl version 2>/dev/null || echo "version check skipped"
+
+          LOG_FILE=".build/compat-results/test-${CLI_VERSION}.log"
+          E2E=1 go test -v -timeout 20m ./test/e2e/cli 2>&1 | tee "${LOG_FILE}"
+          TEST_EXIT=${PIPESTATUS[0]}
+
+          RESULT="pass"
+          FAILED_TESTS=""
+          if [ $TEST_EXIT -ne 0 ]; then
+            RESULT="fail"
+            FAILED_TESTS=$(grep -E '^\s*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
+          fi
+
+          cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON
+          {
+            "server_version": "${{ matrix.server_version }}",
+            "cli_version": "${CLI_VERSION}",
+            "kpt_version": "$(cat .build/kpt-version.txt 2>/dev/null || echo 'unknown')",
+            "result": "${RESULT}",
+            "failed_tests": "${FAILED_TESTS}"
+          }
+          EOJSON
+          echo "Result: ${RESULT} | Failed tests: ${FAILED_TESTS}"
 
       # --- Step 7: Upload results + server logs ---
 

--- a/.github/workflows/porch-compat-matrix.yaml
+++ b/.github/workflows/porch-compat-matrix.yaml
@@ -16,6 +16,7 @@ name: CLI Compatibility Matrix
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     - cron: "0 8 * * 1" # Every Monday at 8AM UTC
 

--- a/.github/workflows/porch-compat-matrix.yaml
+++ b/.github/workflows/porch-compat-matrix.yaml
@@ -91,6 +91,18 @@ jobs:
           repository: kptdev/porch
           ref: ${{ matrix.server_version }}
 
+      - name: Overlay scripts from main
+        if: matrix.server_version != 'latest'
+        uses: actions/checkout@v4
+        with:
+          repository: kptdev/porch
+          ref: main
+          sparse-checkout: scripts
+          path: .scripts-main
+      - name: Copy scripts from main
+        if: matrix.server_version != 'latest'
+        run: cp -r .scripts-main/scripts/. scripts/
+
       # --- Step 2: Setup tooling ---
 
       - name: Set up Go

--- a/.github/workflows/porch-compat-matrix.yaml
+++ b/.github/workflows/porch-compat-matrix.yaml
@@ -177,100 +177,19 @@ jobs:
 
       - name: "porch-server ${{ matrix.server_version }} vs porchctl latest CLI Test"
         id: test-cli-latest
-        run: |
-          set +e
-          CLI_VERSION="latest"
-          cp "${GITHUB_WORKSPACE}/.build/cli/${CLI_VERSION}/porchctl" "${GITHUB_WORKSPACE}/.build/porchctl"
-          echo "Using porchctl from ${CLI_VERSION}:"
-          .build/porchctl version 2>/dev/null || echo "version check skipped"
-
-          LOG_FILE=".build/compat-results/test-${CLI_VERSION}.log"
-          E2E=1 go test -v -timeout 20m ./test/e2e/cli 2>&1 | tee "${LOG_FILE}"
-          TEST_EXIT=${PIPESTATUS[0]}
-
-          RESULT="pass"
-          FAILED_TESTS=""
-          if [ $TEST_EXIT -ne 0 ]; then
-            RESULT="fail"
-            FAILED_TESTS=$(grep -E '^[[:space:]]*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
-          fi
-
-          cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON
-          {
-            "server_version": "${{ matrix.server_version }}",
-            "cli_version": "${CLI_VERSION}",
-            "kpt_version": "$(cat .build/kpt-version.txt 2>/dev/null || echo 'unknown')",
-            "result": "${RESULT}",
-            "failed_tests": "${FAILED_TESTS}"
-          }
-          EOJSON
-          echo "Result: ${RESULT} | Failed tests: ${FAILED_TESTS}"
+        run: ./scripts/run-compat-cli-test.sh latest "${{ matrix.server_version }}"
 
       # --- Step 6.2: Run CLI tests - porchctl n-1 ---
 
       - name: "porch-server ${{ matrix.server_version }} vs porchctl ${{ fromJson(needs.resolve-versions.outputs.releases)[0] }} CLI Test"
         id: test-cli-n1
-        run: |
-          set +e
-          CLI_VERSION=$(echo "$RELEASES" | jq -r '.[0]')
-          cp "${GITHUB_WORKSPACE}/.build/cli/${CLI_VERSION}/porchctl" "${GITHUB_WORKSPACE}/.build/porchctl"
-          echo "Using porchctl from ${CLI_VERSION}:"
-          .build/porchctl version 2>/dev/null || echo "version check skipped"
-
-          LOG_FILE=".build/compat-results/test-${CLI_VERSION}.log"
-          E2E=1 go test -v -timeout 20m ./test/e2e/cli 2>&1 | tee "${LOG_FILE}"
-          TEST_EXIT=${PIPESTATUS[0]}
-
-          RESULT="pass"
-          FAILED_TESTS=""
-          if [ $TEST_EXIT -ne 0 ]; then
-            RESULT="fail"
-            FAILED_TESTS=$(grep -E '^[[:space:]]*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
-          fi
-
-          cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON
-          {
-            "server_version": "${{ matrix.server_version }}",
-            "cli_version": "${CLI_VERSION}",
-            "kpt_version": "$(cat .build/kpt-version.txt 2>/dev/null || echo 'unknown')",
-            "result": "${RESULT}",
-            "failed_tests": "${FAILED_TESTS}"
-          }
-          EOJSON
-          echo "Result: ${RESULT} | Failed tests: ${FAILED_TESTS}"
+        run: ./scripts/run-compat-cli-test.sh "$(echo "$RELEASES" | jq -r '.[0]')" "${{ matrix.server_version }}"
 
       # --- Step 6.3: Run CLI tests - porchctl n-2 ---
 
       - name: "porch-server ${{ matrix.server_version }} vs porchctl ${{ fromJson(needs.resolve-versions.outputs.releases)[1] }} CLI Test"
         id: test-cli-n2
-        run: |
-          set +e
-          CLI_VERSION=$(echo "$RELEASES" | jq -r '.[1]')
-          cp "${GITHUB_WORKSPACE}/.build/cli/${CLI_VERSION}/porchctl" "${GITHUB_WORKSPACE}/.build/porchctl"
-          echo "Using porchctl from ${CLI_VERSION}:"
-          .build/porchctl version 2>/dev/null || echo "version check skipped"
-
-          LOG_FILE=".build/compat-results/test-${CLI_VERSION}.log"
-          E2E=1 go test -v -timeout 20m ./test/e2e/cli 2>&1 | tee "${LOG_FILE}"
-          TEST_EXIT=${PIPESTATUS[0]}
-
-          RESULT="pass"
-          FAILED_TESTS=""
-          if [ $TEST_EXIT -ne 0 ]; then
-            RESULT="fail"
-            FAILED_TESTS=$(grep -E '^[[:space:]]*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
-          fi
-
-          cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON
-          {
-            "server_version": "${{ matrix.server_version }}",
-            "cli_version": "${CLI_VERSION}",
-            "kpt_version": "$(cat .build/kpt-version.txt 2>/dev/null || echo 'unknown')",
-            "result": "${RESULT}",
-            "failed_tests": "${FAILED_TESTS}"
-          }
-          EOJSON
-          echo "Result: ${RESULT} | Failed tests: ${FAILED_TESTS}"
+        run: ./scripts/run-compat-cli-test.sh "$(echo "$RELEASES" | jq -r '.[1]')" "${{ matrix.server_version }}"
 
       # --- Step 7: Upload results + server logs ---
 

--- a/scripts/run-compat-cli-test.sh
+++ b/scripts/run-compat-cli-test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o pipefail
+
+CLI_VERSION="${1:?Usage: $0 <cli_version> <server_version>}"
+SERVER_VERSION="${2:?Usage: $0 <cli_version> <server_version>}"
+
+cp "${GITHUB_WORKSPACE}/.build/cli/${CLI_VERSION}/porchctl" "${GITHUB_WORKSPACE}/.build/porchctl"
+echo "Using porchctl from ${CLI_VERSION}:"
+.build/porchctl version 2>/dev/null || echo "version check skipped"
+
+LOG_FILE=".build/compat-results/test-${CLI_VERSION}.log"
+set +e
+E2E=1 go test -v -timeout 20m ./test/e2e/cli 2>&1 | tee "${LOG_FILE}"
+TEST_EXIT=${PIPESTATUS[0]}
+set -e
+
+RESULT="pass"
+FAILED_TESTS=""
+if [ "${TEST_EXIT}" -ne 0 ]; then
+  RESULT="fail"
+  FAILED_TESTS=$(grep -E '^[[:space:]]*--- FAIL:' "${LOG_FILE}" | sed 's/.*--- FAIL: //' | sed 's/ (.*//' | tr '\n' ',' | sed 's/,$//')
+fi
+
+cat > ".build/compat-results/result-${CLI_VERSION}.json" <<EOJSON
+{
+  "server_version": "${SERVER_VERSION}",
+  "cli_version": "${CLI_VERSION}",
+  "kpt_version": "$(cat .build/kpt-version.txt 2>/dev/null || echo 'unknown')",
+  "result": "${RESULT}",
+  "failed_tests": "${FAILED_TESTS}"
+}
+EOJSON
+
+echo "Result: ${RESULT} | Failed tests: ${FAILED_TESTS}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

<!-- Short, descriptive title for the PR -->
Fixed CLI Compatibility Matrix runs

---

## Description
<!-- Describe what this PR does and why -->
- What changed: 
  - only 3 runs (latest + n-2)
  - using main latest (no longer 1.5)
  - using only semantic versions from releases (not api/test/dummy releases e.g. v1.6.0-pre1 | api/v1.0.0 )
  - each server vs ctl test is isolated in logs (for easier debug) (leads to a bit of duplication but should be a cleaner read)
- Why it’s needed: it was broken due to scraping porch "releases" that didnt have binaries/assets
- How it works: every week same as before a run is made

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. just view the weekly/pr job
2. 
3. 

---

## Additional Notes (Optional)
- Known issues: 
- Further improvements: 
- Review notes: 

---

## AI Disclosure

- [x] **I have NOT used AI in the creation of this PR.**
