### PR TITLE
Set subpackage mutations to always be non-deployment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
         "projectKey": "kptdev_porch"
     },
     "go.testEnvVars": {
-      "E2E": "1",
       "RUN_E2E_LOCALLY": "false",
       "PORCH_SQL_SCHEMA": "${workspaceFolder}/api/sql/porch-db.sql"
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "projectKey": "kptdev_porch"
     },
     "go.testEnvVars": {
+      "E2E": "1",
       "RUN_E2E_LOCALLY": "false",
       "PORCH_SQL_SCHEMA": "${workspaceFolder}/api/sql/porch-db.sql"
     }

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -258,7 +258,7 @@ func (th *genericTaskHandler) applySubpackageTask(
 		return pkgerrors.Wrapf(err, "cannot find repository for draft PR %+v", draft.Key())
 	}
 
-	mut, err := th.mapTaskToMutation(obj, &obj.Spec.Tasks[1], repo.Spec.Deployment, nil)
+	mut, err := th.mapTaskToMutation(obj, &obj.Spec.Tasks[1], false, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -253,6 +253,11 @@ func (th *genericTaskHandler) applySubpackageTask(
 		return pkgerrors.New("for subpackage tasks, the task list must contain exactly 2 tasks, the source task followed by the subpackage task")
 	}
 
+	var repo configapi.Repository
+	if err := th.referenceResolver.ResolveReference(ctx, draft.Key().RKey().K8SNS(), draft.Key().RKey().K8SName(), &repo); err != nil {
+		return pkgerrors.Wrapf(err, "cannot find repository for draft PR %+v", draft.Key())
+	}
+
 	mut, err := th.mapTaskToMutation(obj, &obj.Spec.Tasks[1], false, nil)
 	if err != nil {
 		return err

--- a/pkg/task/generictaskhandler.go
+++ b/pkg/task/generictaskhandler.go
@@ -253,11 +253,6 @@ func (th *genericTaskHandler) applySubpackageTask(
 		return pkgerrors.New("for subpackage tasks, the task list must contain exactly 2 tasks, the source task followed by the subpackage task")
 	}
 
-	var repo configapi.Repository
-	if err := th.referenceResolver.ResolveReference(ctx, draft.Key().RKey().K8SNS(), draft.Key().RKey().K8SName(), &repo); err != nil {
-		return pkgerrors.Wrapf(err, "cannot find repository for draft PR %+v", draft.Key())
-	}
-
 	mut, err := th.mapTaskToMutation(obj, &obj.Spec.Tasks[1], false, nil)
 	if err != nil {
 		return err

--- a/pkg/task/generictaskhandler_test.go
+++ b/pkg/task/generictaskhandler_test.go
@@ -865,29 +865,6 @@ func TestApplySubpackageTask(t *testing.T) {
 			expectedError: "task list must contain exactly 2 tasks",
 		},
 		{
-			name: "Error when reference resolver fails",
-			obj: &porchapi.PackageRevision{
-				Spec: porchapi.PackageRevisionSpec{
-					Tasks: []porchapi.Task{
-						{Type: porchapi.TaskTypeClone, Clone: &porchapi.PackageCloneTaskSpec{}},
-						{Type: porchapi.TaskTypeClone, Clone: &porchapi.PackageCloneTaskSpec{
-							SubpackageDir: "subpkg",
-							Upstream: porchapi.UpstreamPackage{
-								Type: porchapi.RepositoryTypeGit,
-								Git: &porchapi.GitPackage{
-									Repo: "https://github.com/example/repo.git",
-									Ref:  "main",
-								},
-							},
-						}},
-					},
-				},
-			},
-			resources:     repository.PackageResources{Contents: map[string]string{}},
-			resolveErr:    fmt.Errorf("repository not found"),
-			expectedError: "cannot find repository",
-		},
-		{
 			name: "Error when second task has unsupported type",
 			obj: &porchapi.PackageRevision{
 				Spec: porchapi.PackageRevisionSpec{


### PR DESCRIPTION
# Set subpackage mutations to always be non-deployment, only package mutations can be deployment mutations

---

## Description
- What changed: The deployment flag is always set to `false` on subpackage `clone` and `upgrade` mutaitons
- Why it’s needed: Subpackage task mutations for `clone` and `upgrade` should never be deployment mutations because subpackage mutations never lead to a depplyable package revision and don't need a separate `package-context.yaml`. The main package containing the subpackages has the `package-context-yaml` resources for the entire package and that is what is deployed.
- How it works: The deploy flag is always false

Fixes: https://github.com/kptdev/kpt/issues/4650
---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**
