### PR TITLE
Fix: surface API errors in porchctl instead of masking them as not found

### DIFF
--- a/pkg/cli/commands/rpkg/upgrade/command.go
+++ b/pkg/cli/commands/rpkg/upgrade/command.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kptdev/porch/pkg/util"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/util/retry"
@@ -164,14 +165,17 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	pr := r.findPackageRevision(args[0])
+	pr, err := r.findPackageRevision(args[0])
+	if err != nil {
+		return errors.E(op, pkgerrors.Wrapf(err, "error fetching package revision %s", args[0]))
+	}
 	if pr == nil {
 		return errors.E(op, pkgerrors.Errorf("could not find package revision %s", args[0]))
 	}
 	key := client.ObjectKeyFromObject(pr)
 	var upgradedPR *porchapiv1alpha1.PackageRevision
 	var lastErr error
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
 		if err = r.client.Get(r.ctx, key, pr); err != nil {
 			lastErr = err
 			return err
@@ -215,13 +219,19 @@ func (r *runner) doUpgrade(pr *porchapiv1alpha1.PackageRevision) (*porchapiv1alp
 		return nil, pkgerrors.Errorf("to upgrade a package, it must be in a published state, not %q", pr.Spec.Lifecycle)
 	}
 
-	oldUpstreamName := r.findUpstreamName(pr)
+	oldUpstreamName, err := r.findUpstreamName(pr)
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "error finding upstream for package revision %q", pr.Spec.PackageName)
+	}
 	if oldUpstreamName == "" {
 		return nil, pkgerrors.Errorf("upstream source not found for package revision %q:"+
 			" no clone or upgrade type package revision was found in the history of the package", pr.Spec.PackageName)
 	}
 
-	oldUpstreamPr := r.findPackageRevision(oldUpstreamName)
+	oldUpstreamPr, err := r.findPackageRevision(oldUpstreamName)
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "error fetching upstream package revision %s", oldUpstreamName)
+	}
 	if oldUpstreamPr == nil {
 		return nil, pkgerrors.Errorf("upstream package revision %s no longer exists", oldUpstreamName)
 	}
@@ -232,12 +242,18 @@ func (r *runner) doUpgrade(pr *porchapiv1alpha1.PackageRevision) (*porchapiv1alp
 	upstreamRepoName := oldUpstreamPr.Spec.RepositoryName
 	var newUpstreamPr *porchapiv1alpha1.PackageRevision
 	if r.revision == 0 {
-		newUpstreamPr = r.findLatestPackageRevisionForRef(upstreamPackageName, upstreamRepoName)
+		newUpstreamPr, err = r.findLatestPackageRevisionForRef(upstreamPackageName, upstreamRepoName)
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "error finding latest revision for package %s in repo %s", upstreamPackageName, upstreamRepoName)
+		}
 		if newUpstreamPr == nil {
 			return nil, pkgerrors.Errorf("failed to find latest published revision for package %s in repo %s (--revision was %d)", upstreamPackageName, upstreamRepoName, r.revision)
 		}
 	} else {
-		newUpstreamPr = r.findPackageRevisionForRef(upstreamPackageName, upstreamRepoName, r.revision)
+		newUpstreamPr, err = r.findPackageRevisionForRef(upstreamPackageName, upstreamRepoName, r.revision)
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "error finding revision %d for package %s in repo %s", r.revision, upstreamPackageName, upstreamRepoName)
+		}
 		if newUpstreamPr == nil {
 			return nil, pkgerrors.Errorf("revision %d does not exist for package %s in repo %s", r.revision, upstreamPackageName, upstreamRepoName)
 		}
@@ -264,7 +280,7 @@ func (r *runner) doUpgrade(pr *porchapiv1alpha1.PackageRevision) (*porchapiv1alp
 	}
 	newPr := makePackageRevision(pr, r.workspace, upgradeTask)
 
-	err := r.client.Create(r.ctx, newPr)
+	err = r.client.Create(r.ctx, newPr)
 	return newPr, pkgerrors.Wrapf(err, "failed to do create package revision %q", newPr.Name)
 }
 
@@ -308,12 +324,18 @@ func (r *runner) doSubpackageUpgrade(parentPR *porchapiv1alpha1.PackageRevision)
 
 	var newUpstreamPr *porchapiv1alpha1.PackageRevision
 	if r.revision == 0 {
-		newUpstreamPr = r.findLatestPackageRevisionForRef(upstreamPackageName, upstreamRepoName)
+		newUpstreamPr, err = r.findLatestPackageRevisionForRef(upstreamPackageName, upstreamRepoName)
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "error finding latest revision for package %s in repo %s", upstreamPackageName, upstreamRepoName)
+		}
 		if newUpstreamPr == nil {
 			return nil, pkgerrors.Errorf("failed to find latest published revision for package %s in repo %s (--revision was %d)", upstreamPackageName, upstreamRepoName, r.revision)
 		}
 	} else {
-		newUpstreamPr = r.findPackageRevisionForRef(upstreamPackageName, upstreamRepoName, r.revision)
+		newUpstreamPr, err = r.findPackageRevisionForRef(upstreamPackageName, upstreamRepoName, r.revision)
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "error finding revision %d for package %s in repo %s", r.revision, upstreamPackageName, upstreamRepoName)
+		}
 		if newUpstreamPr == nil {
 			return nil, pkgerrors.Errorf("revision %d does not exist for package %s in repo %s", r.revision, upstreamPackageName, upstreamRepoName)
 		}
@@ -368,7 +390,7 @@ func makePackageRevision(oldLocal *porchapiv1alpha1.PackageRevision, workspace s
 	}
 }
 
-func (r *runner) findPackageRevision(prName string) *porchapiv1alpha1.PackageRevision {
+func (r *runner) findPackageRevision(prName string) (*porchapiv1alpha1.PackageRevision, error) {
 	// Use GET instead of searching through cached list
 	if r.discover == "" {
 		pr := &porchapiv1alpha1.PackageRevision{}
@@ -377,21 +399,21 @@ func (r *runner) findPackageRevision(prName string) *porchapiv1alpha1.PackageRev
 			ns = *r.cfg.Namespace
 		}
 		if err := r.client.Get(r.ctx, client.ObjectKey{Namespace: ns, Name: prName}, pr); err != nil {
-			return nil
+			return nil, err
 		}
-		return pr
+		return pr, nil
 	}
 	// Discover mode uses cached list
 	for i := range r.prs {
 		pr := r.prs[i]
 		if pr.Name == prName {
-			return &pr
+			return &pr, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
-func (r *runner) findPackageRevisionForRef(name, repo string, revision int) *porchapiv1alpha1.PackageRevision {
+func (r *runner) findPackageRevisionForRef(name, repo string, revision int) (*porchapiv1alpha1.PackageRevision, error) {
 	// Use List with server-side filtering by package name, repo, and revision
 	if r.discover == "" {
 		list := &porchapiv1alpha1.PackageRevisionList{}
@@ -421,28 +443,28 @@ func (r *runner) findPackageRevisionForRef(name, repo string, revision int) *por
 		}
 
 		if err := r.client.List(r.ctx, list, listOpts...); err != nil {
-			return nil
+			return nil, err
 		}
 
 		for i := range list.Items {
 			pr := &list.Items[i]
 			if pr.Spec.PackageName == name && pr.Spec.RepositoryName == repo && pr.IsPublished() && pr.Spec.Revision == revision {
-				return pr
+				return pr, nil
 			}
 		}
-		return nil
+		return nil, nil
 	}
 	// Discover mode uses cached list
 	for i := range r.prs {
 		pr := r.prs[i]
 		if pr.Spec.PackageName == name && pr.Spec.RepositoryName == repo && pr.IsPublished() && pr.Spec.Revision == revision {
-			return &pr
+			return &pr, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
-func (r *runner) findLatestPackageRevisionForRef(name, repo string) *porchapiv1alpha1.PackageRevision {
+func (r *runner) findLatestPackageRevisionForRef(name, repo string) (*porchapiv1alpha1.PackageRevision, error) {
 	// Discovery mode always uses cached list
 	if r.discover != "" {
 		latest := 0
@@ -453,7 +475,7 @@ func (r *runner) findLatestPackageRevisionForRef(name, repo string) *porchapiv1a
 				output = &pr
 			}
 		}
-		return output
+		return output, nil
 	}
 
 	// Non-discovery mode: list with server-side filtering
@@ -481,7 +503,7 @@ func (r *runner) findLatestPackageRevisionForRef(name, repo string) *porchapiv1a
 	}
 
 	if err := r.client.List(r.ctx, list, listOpts...); err != nil {
-		return nil
+		return nil, err
 	}
 	latest := 0
 	var output *porchapiv1alpha1.PackageRevision
@@ -492,7 +514,7 @@ func (r *runner) findLatestPackageRevisionForRef(name, repo string) *porchapiv1a
 			output = pr
 		}
 	}
-	return output
+	return output, nil
 }
 
 func (r *runner) findPackageRevisionFromUpstream(upstream *kptfilev1.Upstream) (*porchapiv1alpha1.PackageRevision, error) {
@@ -547,7 +569,10 @@ func (r *runner) findPackageRevisionFromUpstream(upstream *kptfilev1.Upstream) (
 		return nil, pkgerrors.Errorf("invalid git ref %q (expected vN) for repository %q directory %q", upstream.Git.Ref, upstream.Git.Repo, upstream.Git.Directory)
 	}
 
-	foundPR := r.findPackageRevisionForRef(upstreamPkg, foundRepo.Name, revision)
+	foundPR, err := r.findPackageRevisionForRef(upstreamPkg, foundRepo.Name, revision)
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "error finding package revision for repo %q package name %q revision %d", foundRepo.Name, upstreamPkg, revision)
+	}
 	if foundPR == nil {
 		return nil, pkgerrors.Errorf("could not find package revision for repo %q package name %q revision %d", foundRepo.Name, upstreamPkg, revision)
 	}
@@ -555,40 +580,51 @@ func (r *runner) findPackageRevisionFromUpstream(upstream *kptfilev1.Upstream) (
 	return foundPR, nil
 }
 
-func (r *runner) findUpstreamName(pr *porchapiv1alpha1.PackageRevision) string {
+func (r *runner) findUpstreamName(pr *porchapiv1alpha1.PackageRevision) (string, error) {
 	switch pr.Spec.Tasks[0].Type {
 	case porchapiv1alpha1.TaskTypeClone:
-		return pr.Spec.Tasks[0].Clone.Upstream.UpstreamRef.Name
+		return pr.Spec.Tasks[0].Clone.Upstream.UpstreamRef.Name, nil
 	case porchapiv1alpha1.TaskTypeEdit:
-		if n := r.findEditOrigin(pr); n != "" {
-			return n
+		n, err := r.findEditOrigin(pr)
+		if err != nil {
+			return "", err
+		}
+		if n != "" {
+			return n, nil
 		}
 		if pr.Status.UpstreamLock != nil {
 			if err := r.listPackageRevisions(); err != nil {
-				return ""
+				return "", err
 			}
 			if up := r.findUpstreamByLock(pr.Status.UpstreamLock); up != nil {
-				return up.Name
+				return up.Name, nil
 			}
 		}
-		return ""
+		return "", nil
 	case porchapiv1alpha1.TaskTypeUpgrade:
-		return pr.Spec.Tasks[0].Upgrade.NewUpstream.Name
+		return pr.Spec.Tasks[0].Upgrade.NewUpstream.Name, nil
 	default:
-		return ""
+		return "", nil
 	}
 }
 
-func (r *runner) findEditOrigin(currentPr *porchapiv1alpha1.PackageRevision) string {
+func (r *runner) findEditOrigin(currentPr *porchapiv1alpha1.PackageRevision) (string, error) {
 	pr := currentPr
 	for pr != nil && pr.Spec.Tasks[0].Type == porchapiv1alpha1.TaskTypeEdit {
 		sourceName := pr.Spec.Tasks[0].Edit.Source.Name
-		pr = r.findPackageRevision(sourceName)
+		found, err := r.findPackageRevision(sourceName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return "", nil
+			}
+			return "", err
+		}
+		pr = found
 	}
 	if pr != nil {
 		return r.findUpstreamName(pr)
 	}
-	return ""
+	return "", nil
 }
 
 func (r *runner) listPackageRevisions() error {

--- a/pkg/cli/commands/rpkg/upgrade/command_test.go
+++ b/pkg/cli/commands/rpkg/upgrade/command_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -312,7 +313,7 @@ func TestUpgradeCommand(t *testing.T) {
 			name:           "Non-existent package revision",
 			args:           []string{"non-existent-revision"},
 			expectedOutput: "",
-			expectedError:  "could not find package revision non-existent-revision",
+			expectedError:  "error fetching package revision non-existent-revision",
 			runner:         commonRunner,
 		},
 	}
@@ -373,7 +374,8 @@ func TestFindLatestPR(t *testing.T) {
 
 	r := createRunner(context.Background(), client, prs, "ns", 0)
 
-	found := r.findLatestPackageRevisionForRef("orig", "repo")
+	found, err := r.findLatestPackageRevisionForRef("orig", "repo")
+	assert.NoError(t, err)
 	assert.Equal(t, "repo.orig.v2", found.Name)
 	assert.Equal(t, 2, found.Spec.Revision)
 }
@@ -434,7 +436,8 @@ func TestFindEditOrigin(t *testing.T) {
 	// empty prs to force GET-based traversal in findEditOrigin
 	r := createRunner(context.Background(), c, []porchapi.PackageRevision{}, ns, 0)
 
-	found := r.findUpstreamName(&downstreamv3)
+	found, err := r.findUpstreamName(&downstreamv3)
+	assert.NoError(t, err)
 	assert.Equal(t, "upstream.v1", found)
 }
 
@@ -1020,18 +1023,25 @@ func TestFindUpstreamInEditTaskWithUpstreamLock(t *testing.T) {
 	// empty prs to force listPackageRevisions call
 	r := createRunner(context.Background(), c, []porchapi.PackageRevision{}, ns, 0)
 
-	result := r.findUpstreamName(&editPr)
+	result, err := r.findUpstreamName(&editPr)
 
+	assert.NoError(t, err)
 	assert.Equal(t, "upstream-pr-v2", result)
 }
 
 func TestFindUpstreamInEditTaskNoUpstreamLock(t *testing.T) {
 	const ns = "ns"
 
+	scheme := runtime.NewScheme()
+	if err := porchapi.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add porch API to scheme: %v", err)
+	}
+
 	// edit package revision with no upstream lock
 	editPrNoLock := porchapi.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "edit-pr-no-lock",
+			Name:      "edit-pr-no-lock",
+			Namespace: ns,
 		},
 		Spec: porchapi.PackageRevisionSpec{
 			Tasks: []porchapi.Task{
@@ -1051,10 +1061,11 @@ func TestFindUpstreamInEditTaskNoUpstreamLock(t *testing.T) {
 	}
 
 	prs := []porchapi.PackageRevision{editPrNoLock}
-	r := createRunner(context.Background(), fake.NewClientBuilder().Build(), prs, ns, 0)
+	r := createRunner(context.Background(), fake.NewClientBuilder().WithScheme(scheme).Build(), prs, ns, 0)
 
-	result := r.findUpstreamName(&editPrNoLock)
+	result, err := r.findUpstreamName(&editPrNoLock)
 
+	require.NoError(t, err)
 	assert.Equal(t, "", result)
 }
 
@@ -1082,8 +1093,9 @@ func TestFindUpstreamInUpgradeTask(t *testing.T) {
 	prs := []porchapi.PackageRevision{upgradePr}
 	r := createRunner(context.Background(), fake.NewClientBuilder().Build(), prs, ns, 0)
 
-	result := r.findUpstreamName(&upgradePr)
+	result, err := r.findUpstreamName(&upgradePr)
 
+	require.NoError(t, err)
 	assert.Equal(t, "new-upstream-v2", result)
 }
 
@@ -1510,4 +1522,97 @@ func TestAvailableUpdatesWithDirectory(t *testing.T) {
 	assert.Len(t, availableUpdates, 2, "Should find v2 and v3 as available updates")
 	assert.Equal(t, 2, availableUpdates[0].Spec.Revision)
 	assert.Equal(t, 3, availableUpdates[1].Spec.Revision)
+}
+
+// TestUnauthorizedErrorNotMasked verifies that a 401 Unauthorized error from the
+// API server is properly surfaced to the user, not masked as "could not find package revision".
+func TestUnauthorizedErrorNotMasked(t *testing.T) {
+	const ns = "ns"
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, porchapi.AddToScheme(scheme))
+
+	unauthorizedErr := apierrors.NewUnauthorized("Unauthorized")
+
+	t.Run("findPackageRevision surfaces 401 error", func(t *testing.T) {
+		// Use interceptor to return 401 on Get
+		interceptorFuncs := interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return unauthorizedErr
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithInterceptorFuncs(interceptorFuncs).
+			Build()
+
+		r := createRunner(ctx, c, nil, ns, 2)
+
+		pr, err := r.findPackageRevision("some-package")
+		assert.Nil(t, pr)
+		assert.Error(t, err)
+		assert.True(t, apierrors.IsUnauthorized(err), "expected Unauthorized error, got: %v", err)
+	})
+
+	t.Run("findPackageRevisionForRef surfaces 401 error", func(t *testing.T) {
+		// Use interceptor to return 401 on List
+		interceptorFuncs := interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				return unauthorizedErr
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithInterceptorFuncs(interceptorFuncs).
+			Build()
+
+		r := createRunner(ctx, c, nil, ns, 2)
+
+		pr, err := r.findPackageRevisionForRef("pkg", "repo", 1)
+		assert.Nil(t, pr)
+		assert.Error(t, err)
+		assert.True(t, apierrors.IsUnauthorized(err), "expected Unauthorized error, got: %v", err)
+	})
+
+	t.Run("findLatestPackageRevisionForRef surfaces 401 error", func(t *testing.T) {
+		// Use interceptor to return 401 on List
+		interceptorFuncs := interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				return unauthorizedErr
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithInterceptorFuncs(interceptorFuncs).
+			Build()
+
+		r := createRunner(ctx, c, nil, ns, 0)
+
+		pr, err := r.findLatestPackageRevisionForRef("pkg", "repo")
+		assert.Nil(t, pr)
+		assert.Error(t, err)
+		assert.True(t, apierrors.IsUnauthorized(err), "expected Unauthorized error, got: %v", err)
+	})
+
+	t.Run("runE surfaces 401 error instead of masking it", func(t *testing.T) {
+		// Use interceptor to return 401 on Get (simulates what happens during upgrade)
+		interceptorFuncs := interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return unauthorizedErr
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithInterceptorFuncs(interceptorFuncs).
+			Build()
+
+		r := createRunner(ctx, c, nil, ns, 2)
+
+		err := r.runE(r.Command, []string{"some-package-revision"})
+		assert.Error(t, err)
+		// The error should mention "Unauthorized", not just "could not find"
+		assert.Contains(t, err.Error(), "Unauthorized")
+		assert.NotContains(t, err.Error(), "could not find package revision")
+	})
 }

--- a/pkg/cli/commands/rpkg/upgrade/discover.go
+++ b/pkg/cli/commands/rpkg/upgrade/discover.go
@@ -34,7 +34,11 @@ func (r *runner) discoverUpdates(cmd *cobra.Command, args []string) error {
 		prs = r.prs
 	} else {
 		for i := range args {
-			pr := r.findPackageRevision(args[i])
+			pr, err := r.findPackageRevision(args[i])
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("error fetching package revision %s: %v", args[i], err))
+				continue
+			}
 			if pr == nil {
 				errs = append(errs, fmt.Sprintf("could not find package revision %s", args[i]))
 				continue

--- a/pkg/registry/porch/packagerevision.go
+++ b/pkg/registry/porch/packagerevision.go
@@ -102,6 +102,7 @@ func (r *packageRevisions) List(ctx context.Context, options *metainternalversio
 		result.Items = append(result.Items, *item)
 		return nil
 	}); err != nil {
+		klog.Errorf("[API] List operation failed for PackageRevisions: %v", err)
 		return nil, err
 	}
 
@@ -122,6 +123,7 @@ func (r *packageRevisions) Get(ctx context.Context, name string, _ *metav1.GetOp
 
 	repoPkgRev, err := r.getRepoPkgRev(ctx, name)
 	if err != nil {
+		klog.Errorf("[API] Get operation failed for PackageRevision %s: %v", name, err)
 		return nil, err
 	}
 
@@ -315,6 +317,7 @@ func (r *packageRevisions) Delete(ctx context.Context, name string, deleteValida
 
 	repoPkgRev, err := r.getRepoPkgRev(ctx, name)
 	if err != nil {
+		klog.Errorf("[API] Delete operation failed for PackageRevision %s: %v", name, err)
 		return nil, false, err
 	}
 

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -97,6 +97,7 @@ func (r *packageRevisionResources) List(ctx context.Context, options *metaintern
 		result.Items = append(result.Items, *apiPkgResources)
 		return nil
 	}); err != nil {
+		klog.Errorf("[API] List operation failed for PackageRevisionResources: %v", err)
 		return nil, err
 	}
 
@@ -117,6 +118,7 @@ func (r *packageRevisionResources) Get(ctx context.Context, name string, _ *meta
 
 	pkg, err := r.getRepoPkgRevForResources(ctx, name)
 	if err != nil {
+		klog.Errorf("[API] Get operation failed for PackageRevisionResources %s: %v", name, err)
 		return nil, err
 	}
 
@@ -159,6 +161,7 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 
 	oldRepoPkgRev, err := r.getRepoPkgRevForResources(ctx, name)
 	if err != nil {
+		klog.Errorf("[API] Update operation failed for PackageRevisionResources %s: %v", name, err)
 		return nil, false, err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

<!-- Short, descriptive title for the PR -->
# Fix: surface API errors in porchctl instead of masking them as not found

---

## Description
<!-- Describe what this PR does and why -->

No changes required for v1alpha2.

- What changed: 
 porchctl CLI: findPackageRevision, findPackageRevisionForRef, findLatestPackageRevisionForRef, findUpstreamName, and EditOrigin now return errors instead of swallowing them and returning nil. Porch API server: added error logging at the handler level for List, Get, and Delete operations in packagerevision.go and packagerevisionresources.go. Added testUnauthorizedErrorNotMasked test covering all affected methods.
 
- Why it’s needed: 
porchctl rpkg upgrade masked HTTP errors (e.g. 401 Unauthorized) as "could not find package revision <name>", making auth and connectivity failures impossible to diagnose without -v 10. On the server side, failed List/Get operations were returned to the client but never logged, making server-side troubleshooting difficult.
  
- How it works: 
The find* methods now return (result, error) tuples. Callers check the error first — if non-nil, they wrap and propagate it with context. A nil result with nil error means "genuinely not found". In findEditOrigin, NotFound errors are treated as non-errors to preserve the fallback to upstream lock resolution. Server-side logging is done at the calling handlers (not shared helpers) so each log line includes the operation context (List/Get/Delete).

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [x] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. 
2. 
3. 

---

## Additional Notes (Optional)
- Known issues: 
- Further improvements: 
- Review notes: 

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

Kiro to generate unit tests and verify code correctness.
