### PR TITLE
Docs: documenting Resource ID clash during clone

### DIFF
--- a/docs/content/en/docs/2_concepts/subpackages.md
+++ b/docs/content/en/docs/2_concepts/subpackages.md
@@ -83,7 +83,7 @@ one after another before it is proposed and approved.
 - For clone: the subdirectory must **not already exist** in the package
 - For upgrade: the subdirectory **must already exist** and contain a valid `Kptfile` with upstream information
 - `--workspace` and `--repository` must not be specified when using `--subpackage-dir`
-- For clone: If parent has a pipeline each resource in both parent and subpackage must have a unique [GVKNN](https://kpt.dev/guides/variant-constructor-pattern/#customizing-identity-of-resources) identifier.
+- For clone: if the parent package revision has a pipeline, each resource in both parent and subpackage must have a unique [GVKNN](https://kpt.dev/guides/variant-constructor-pattern/#customizing-identity-of-resources) identifier.
 
 ## Subpackages vs Regular Clone
 

--- a/docs/content/en/docs/2_concepts/subpackages.md
+++ b/docs/content/en/docs/2_concepts/subpackages.md
@@ -83,6 +83,7 @@ one after another before it is proposed and approved.
 - For clone: the subdirectory must **not already exist** in the package
 - For upgrade: the subdirectory **must already exist** and contain a valid `Kptfile` with upstream information
 - `--workspace` and `--repository` must not be specified when using `--subpackage-dir`
+- For clone: If parent has a pipeline each resource in both parent and subpackage must have a unique [GVKNN](https://kpt.dev/guides/variant-constructor-pattern/#customizing-identity-of-resources) identifier.
 
 ## Subpackages vs Regular Clone
 

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/working-with-subpackages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/working-with-subpackages.md
@@ -261,6 +261,11 @@ porchctl rpkg upgrade deployments.my-composed-app.v2 \
 - The path must be a relative directory without leading `/`, `./`, or `..` segments
 - Example valid paths: `components/networking`, `subpkgs/monitoring`, `infra`
 
+**Clone fails with "may not add resource with an already registered id"?**
+
+- The parent has a pipeline and a resource in the subpackage shares a [GVKNN](https://kpt.dev/guides/variant-constructor-pattern/#customizing-identity-of-resources) identifier with one already in the package tree
+- Ensure `metadata.name` fields are unique for each resource.
+
 **Upgrade fails with "could not find Kptfile for independent subpackage"?**
 
 - Verify the subdirectory exists in the parent package and contains a `Kptfile`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

<!-- Short, descriptive title for the PR -->
Docs: documenting Resource ID clash during clone

---

## Description
<!-- Describe what this PR does and why -->
- What changed: a small explanation in subpkg cloning regarding resource ID clashes
- Why it’s needed: 
  1. when a user clones a subpkg if that subpkg has a resource with the same GVKNN it will fail render
  2. the is most likely to happen when a user clones the same upstream subpkg into 2 or more separate subdir's in the parent thus leading to identical GVKNN resource clash.
  3. there is no real mention of this anywhere in porch and only very well hidden in the kpt side.
- How it works: adding 2 notes to clarify the situation for a user of subpkgs

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed changes
- [ ] Tests added/updated
- [x] Documentation added/updated
- [ ] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. 
2. 
4. 

---

## Additional Notes (Optional)
- Known issues: 
- Further improvements: 
- Review notes: 

---

## AI Disclosure

- [x] **I have NOT used AI in the creation of this PR.**
