### PR TITLE
Bugfix Git cleanup on draft/proposed branches when pushDraftsToGit is set on DB cache

### DIFF
--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -427,7 +427,7 @@ func (pr *dbPackageRevision) Delete(ctx context.Context, deleteExternal bool) er
 	_, span := tracer.Start(ctx, "dbPackageRevision::Delete", trace.WithAttributes())
 	defer span.End()
 
-	if deleteExternal && porchapi.LifecycleIsPublished(pr.lifecycle) {
+	if deleteExternal && (porchapi.LifecycleIsPublished(pr.lifecycle) || pr.repo.pushDraftsToGit) {
 		if err := pr.repo.externalRepo.DeletePackageRevision(ctx, pr); err != nil {
 			// Check if the error indicates the package doesn't exist in external repo
 			if repository.IsNotFoundError(err) {

--- a/pkg/cache/dbcache/dbrepository.go
+++ b/pkg/cache/dbcache/dbrepository.go
@@ -291,7 +291,7 @@ func (r *dbRepository) DeletePackageRevision(ctx context.Context, pr2Delete repo
 
 	// Only published packages are deleted from external repo
 	// TODO should be replaced with flag when option for db-cache push to git regardless PR comes in
-	if porchapi.LifecycleIsPublished(pr2Delete.Lifecycle(context.Background())) {
+	if porchapi.LifecycleIsPublished(pr2Delete.Lifecycle(context.Background())) || r.pushDraftsToGit {
 		klog.InfoS("[DB Cache] Deleting PackageRevision from database and external repo for PackageRevision",
 			pctx.LogMetadataFrom(ctx)...)
 		defer func() {

--- a/pkg/cache/dbcache/dbrepository_test.go
+++ b/pkg/cache/dbcache/dbrepository_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kptdev/porch/pkg/repository"
 	mocksql "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/cache/dbcache"
 	mockcachetypes "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/cache/types"
+	mockrepo "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/repository"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -218,4 +219,110 @@ func (t *DbTestSuite) TestDBRepositorCorner() {
 	t.Require().NotNil(err)
 
 	t.revertToPostgreSQL()
+}
+
+// newPushDraftsToGitTestRepo returns a repository backed by a mock external repository, so
+// that calls made to git are asserted rather than silently absorbed by the fake repository.
+func (t *DbTestSuite) newPushDraftsToGitTestRepo(namespace, name string, pushDraftsToGit bool) (*dbRepository, *mockrepo.MockRepository) {
+	mockCache := mockcachetypes.NewMockCache(t.T())
+	cachetypes.CacheInstance = mockCache
+	externalrepo.ExternalRepoInUnitTestMode = true
+
+	testRepo := t.createTestRepo(namespace, name)
+	mockCache.EXPECT().GetRepository(mock.Anything).Return(testRepo).Maybe()
+
+	extRepo := mockrepo.NewMockRepository(t.T())
+	extRepo.EXPECT().Key().Return(repository.RepositoryKey{Namespace: namespace, Name: name}).Maybe()
+
+	testRepo.externalRepo = extRepo
+	testRepo.pushDraftsToGit = pushDraftsToGit
+	if pushDraftsToGit {
+		testRepo.gitPRCache = make(map[string]repository.PackageRevision)
+	}
+
+	return testRepo, extRepo
+}
+
+// TestDBRepositoryDeleteDraftWithPushDraftsToGit checks that deleting an unpublished
+// package revision also deletes it from git when pushDraftsToGit is set. The draft branch
+// only exists in git because the flag is set, so it has to be cleaned up on delete;
+// otherwise the branch is orphaned.
+func (t *DbTestSuite) TestDBRepositoryDeleteDraftWithPushDraftsToGit() {
+	ctx := t.Context()
+	namespace := "my-ns"
+	repoName := "delete-draft-push-repo"
+
+	testRepo, extRepo := t.newPushDraftsToGitTestRepo(namespace, repoName, true)
+
+	gitDraft := mockrepo.NewMockPackageRevisionDraft(t.T())
+	gitPR := mockrepo.NewMockPackageRevision(t.T())
+	extRepo.EXPECT().CreatePackageRevisionDraft(mock.Anything, mock.Anything).Return(gitDraft, nil).Once()
+	extRepo.EXPECT().ClosePackageRevisionDraft(mock.Anything, gitDraft, 0).Return(gitPR, nil).Once()
+
+	newPRDef := porchapi.PackageRevision{
+		Spec: porchapi.PackageRevisionSpec{
+			RepositoryName: repoName,
+			PackageName:    "my-package",
+			WorkspaceName:  "my-workspace",
+			Lifecycle:      porchapi.PackageRevisionLifecycleDraft,
+		},
+	}
+
+	prDraft, err := testRepo.CreatePackageRevisionDraft(ctx, &newPRDef)
+	t.Require().NoError(err)
+
+	dbPR, err := testRepo.ClosePackageRevisionDraft(ctx, prDraft, 0)
+	t.Require().NoError(err)
+	t.Require().Equal(porchapi.PackageRevisionLifecycleDraft, dbPR.Lifecycle(ctx))
+	t.Require().Len(testRepo.gitPRCache, 1)
+
+	// The draft is unpublished, so this is the assertion that would fail if the external
+	// delete were still gated on the lifecycle being published.
+	extRepo.EXPECT().DeletePackageRevision(mock.Anything, dbPR).Return(nil).Once()
+
+	err = testRepo.DeletePackageRevision(ctx, dbPR)
+	t.Require().NoError(err)
+
+	prList, err := testRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{})
+	t.Require().NoError(err)
+	t.Empty(prList, "package revision should be gone from the database")
+	t.Empty(testRepo.gitPRCache, "cached git package revision should be evicted on delete")
+
+	t.deleteTestRepo(testRepo.Key())
+}
+
+// TestDBRepositoryDeleteDraftWithoutPushDraftsToGit is the counterpart of the test above:
+// with pushDraftsToGit unset, an unpublished package revision never existed in git, so no
+// delete may be issued against it. No expectation is registered for
+// DeletePackageRevision, which makes the mock fail the test if it is called.
+func (t *DbTestSuite) TestDBRepositoryDeleteDraftWithoutPushDraftsToGit() {
+	ctx := t.Context()
+	namespace := "my-ns"
+	repoName := "delete-draft-no-push-repo"
+
+	testRepo, _ := t.newPushDraftsToGitTestRepo(namespace, repoName, false)
+
+	newPRDef := porchapi.PackageRevision{
+		Spec: porchapi.PackageRevisionSpec{
+			RepositoryName: repoName,
+			PackageName:    "my-package",
+			WorkspaceName:  "my-workspace",
+			Lifecycle:      porchapi.PackageRevisionLifecycleDraft,
+		},
+	}
+
+	prDraft, err := testRepo.CreatePackageRevisionDraft(ctx, &newPRDef)
+	t.Require().NoError(err)
+
+	dbPR, err := testRepo.ClosePackageRevisionDraft(ctx, prDraft, 0)
+	t.Require().NoError(err)
+
+	err = testRepo.DeletePackageRevision(ctx, dbPR)
+	t.Require().NoError(err)
+
+	prList, err := testRepo.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{})
+	t.Require().NoError(err)
+	t.Empty(prList)
+
+	t.deleteTestRepo(testRepo.Key())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

<!-- Short, descriptive title for the PR -->
Bugfix Git cleanup on draft/proposed branches when pushDraftsToGit is set on DB cache

---

## Description
<!-- Describe what this PR does and why -->
- What changed: changed 2 if statements to also include `pushDraftsToGit` check during PR deletion
- Why it’s needed: resulted in leftover branches
- How it works: its an if statment

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #928 

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. launch locally with flag set and try deletion of PR after creation.
2. ensure git repo is removing branch
3. 

---

## Additional Notes (Optional)
- Known issues: 
- Further improvements: it seems approving PR's with this flag enabled breaks the process amongst other things. didn't include fix in this PR.
- Review notes: 

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro was used to generate unit tests
