### PR TITLE
Update e2e function tests

### DIFF
--- a/.github/workflows/porch-e2e-nightly.yaml
+++ b/.github/workflows/porch-e2e-nightly.yaml
@@ -105,12 +105,12 @@ jobs:
           - name: "Porch CLI E2E Tests (CR Cache)"
             make_target: "run-in-kind"
             test_path: "${GITHUB_WORKSPACE}/test/e2e/cli"
-            test_env: "E2E=1 TPP=1"
+            test_env: "E2E=1"
             log_prefix: "porch-cli-e2e-crcache"
           - name: "Porch Function Runner E2E Tests (CR Cache)"
             make_target: "run-in-kind"
             test_path: "${GITHUB_WORKSPACE}/test/e2e/fn-runner"
-            test_env: "E2E=1"
+            test_env: "E2E=1 TPP=1"
             log_prefix: "porch-fn-runner-e2e-crcache"
 
     steps:

--- a/.github/workflows/porch-e2e-nightly.yaml
+++ b/.github/workflows/porch-e2e-nightly.yaml
@@ -105,8 +105,13 @@ jobs:
           - name: "Porch CLI E2E Tests (CR Cache)"
             make_target: "run-in-kind"
             test_path: "${GITHUB_WORKSPACE}/test/e2e/cli"
-            test_env: "E2E=1"
+            test_env: "E2E=1 TPP=1"
             log_prefix: "porch-cli-e2e-crcache"
+          - name: "Porch Function Runner E2E Tests (CR Cache)"
+            make_target: "run-in-kind"
+            test_path: "${GITHUB_WORKSPACE}/test/e2e/fn-runner"
+            test_env: "E2E=1"
+            log_prefix: "porch-fn-runner-e2e-crcache"
 
     steps:
       - name: Checkout Porch

--- a/.github/workflows/porch-e2e-nightly.yaml
+++ b/.github/workflows/porch-e2e-nightly.yaml
@@ -109,7 +109,7 @@ jobs:
             log_prefix: "porch-cli-e2e-crcache"
           - name: "Porch Function Runner E2E Tests (CR Cache)"
             make_target: "run-in-kind"
-            test_path: "${GITHUB_WORKSPACE}/test/e2e/fn-runner"
+            test_path: "${GITHUB_WORKSPACE}/test/e2e/fn_runner"
             test_env: "E2E=1 TPP=1"
             log_prefix: "porch-fn-runner-e2e-crcache"
 

--- a/test/e2e/fn_runner/3rd_party_kpt_fn_test.go
+++ b/test/e2e/fn_runner/3rd_party_kpt_fn_test.go
@@ -662,13 +662,16 @@ func (t *FunctionRunnerSuite) loadTestCases(functionName string) map[string]func
 func (t *FunctionRunnerSuite) updateWithRetryF(obj client.Object, retries int, timeout time.Duration, opts ...client.UpdateOption) {
 
 	var err error
-	for i := retries; i > 0; i-- {
-		if err = t.Client.Update(t.GetContext(), obj); err == nil {
+	for i := retries; i >= 0; i-- {
+		if err = t.Client.Update(t.GetContext(), obj, opts...); err == nil {
 			break
 		}
-		t.Logf("failed to update resources for test case %s: %v", obj, err)
-		t.Logf("retrying update of resources for test case %s . . .", obj)
-		time.Sleep(timeout)
+		t.Logf("failed to update resources for test case %s: %v", obj.GetName(), err)
+		t.Logf("retrying update of resources for test case %s . . .", obj.GetName())
+
+		if i > 0 {
+			time.Sleep(timeout)
+		}
 	}
 
 	if err != nil {

--- a/test/e2e/fn_runner/3rd_party_kpt_fn_test.go
+++ b/test/e2e/fn_runner/3rd_party_kpt_fn_test.go
@@ -51,6 +51,11 @@ type functionVersions struct {
 	Versions map[string]FunctionVersion `yaml:"versions,omitempty"`
 }
 
+const (
+	updateRetries     = 3
+	retryWaitDuration = 5 * time.Second
+)
+
 func TestE2E(t *testing.T) {
 	// https://github.com/kptdev/porch/pull/256
 	// Updating 3rd party dependencies may break existing kpt functions because of api incompatibility.
@@ -86,7 +91,7 @@ func (t *FunctionRunnerSuite) TestApplySetters() {
 				"projects-namespace": "updated-projects",
 			}))
 
-			t.UpdateF(resources)
+			t.updateWithRetryF(resources, updateRetries, retryWaitDuration)
 			t.failOnRenderError(resources)
 
 			for name, obj := range resources.Spec.Resources {
@@ -127,7 +132,7 @@ func (t *FunctionRunnerSuite) TestSetNamespace() {
 				"namespace": "updated-namespace",
 			}))
 
-			t.UpdateF(resources)
+			t.updateWithRetryF(resources, updateRetries, retryWaitDuration)
 			t.failOnRenderError(resources)
 
 			bucket, ok := resources.Spec.Resources["bucket.yaml"]
@@ -169,7 +174,7 @@ func (t *FunctionRunnerSuite) TestSetLabels() {
 				"app": "updated-cloud-sql-auth-proxy",
 			}))
 
-			t.UpdateF(resources)
+			t.updateWithRetryF(resources, updateRetries, retryWaitDuration)
 			t.failOnRenderError(resources)
 
 			// Get package resources again
@@ -214,7 +219,7 @@ func (t *FunctionRunnerSuite) TestSetAnnotations() {
 				"cnrm.cloud.google.com/blueprint": "updated-cnrm/sql/auth-proxy/v0.2.0",
 			}))
 
-			t.UpdateF(resources)
+			t.updateWithRetryF(resources, updateRetries, retryWaitDuration)
 			t.failOnRenderError(resources)
 
 			daemonset, ok := resources.Spec.Resources["daemonset.yaml"]
@@ -257,7 +262,7 @@ func (t *FunctionRunnerSuite) TestSearchReplace() {
 				"put-value": "updated-cloud-sql-auth-proxy",
 			}))
 
-			t.UpdateF(resources)
+			t.updateWithRetryF(resources, updateRetries, retryWaitDuration)
 			t.failOnRenderError(resources)
 
 			service, ok := resources.Spec.Resources["service.yaml"]
@@ -303,7 +308,7 @@ func (t *FunctionRunnerSuite) TestStarlark() {
   resource["metadata"]["annotations"]["foo"] = "bar"`,
 			}))
 
-			t.UpdateF(resources)
+			t.updateWithRetryF(resources, updateRetries, retryWaitDuration)
 			t.failOnRenderError(resources)
 
 			bucket, ok := resources.Spec.Resources["bucket.yaml"]
@@ -345,7 +350,7 @@ func (t *FunctionRunnerSuite) TestEnsureNameSubstring() {
 				"append": "-test",
 			}))
 
-			t.UpdateF(resources)
+			t.updateWithRetryF(resources, updateRetries, retryWaitDuration)
 			t.failOnRenderError(resources)
 
 			service := resources.Spec.Resources["service.yaml"]
@@ -387,7 +392,7 @@ func (t *FunctionRunnerSuite) TestSetImage() {
 				"newTag":  "1.22.0",
 			}))
 
-			t.UpdateF(resources)
+			t.updateWithRetryF(resources, updateRetries, retryWaitDuration)
 			t.failOnRenderError(resources)
 
 			daemonset, ok := resources.Spec.Resources["daemonset.yaml"]
@@ -445,7 +450,7 @@ func (t *FunctionRunnerSuite) TestApplyReplacements() {
 
 			t.AddMutator(resources, tc.image, suiteutils.WithConfigPath("applyreplacement.yaml"))
 
-			t.UpdateF(resources)
+			t.updateWithRetryF(resources, updateRetries, retryWaitDuration)
 			t.failOnRenderError(resources)
 
 			job, ok := resources.Spec.Resources["job.yaml"]
@@ -493,7 +498,7 @@ func (t *FunctionRunnerSuite) TestCreateSetters() {
 				"nginx-replicas": "5",
 			}))
 
-			t.UpdateF(resources)
+			t.updateWithRetryF(resources, updateRetries, retryWaitDuration)
 			t.failOnRenderError(resources)
 
 			packageResources, ok := resources.Spec.Resources["resources.yaml"]
@@ -652,4 +657,21 @@ func (t *FunctionRunnerSuite) loadTestCases(functionName string) map[string]func
 	}
 
 	return imageMap
+}
+
+func (t *FunctionRunnerSuite) updateWithRetryF(obj client.Object, retries int, timeout time.Duration, opts ...client.UpdateOption) {
+
+	var err error
+	for i := retries; i > 0; i-- {
+		if err = t.Client.Update(t.GetContext(), obj); err == nil {
+			break
+		}
+		t.Logf("failed to update resources for test case %s: %v", obj, err)
+		t.Logf("retrying update of resources for test case %s . . .", obj)
+		time.Sleep(timeout)
+	}
+
+	if err != nil {
+		t.FailNow("failed to update resources for test case after retrying")
+	}
 }

--- a/test/e2e/fn_runner/testdata/function-versions.yaml
+++ b/test/e2e/fn_runner/testdata/function-versions.yaml
@@ -18,12 +18,9 @@ versions:
   starlark:
     latest: v0.5.6
     minus1: v0.5.5
-#  TODO: Re-enable ensure-name-substring tests when the ensure-name-substring krm function is fixed, turn off the `skip: true` flag
-#  see https://github.com/kptdev/kpt/issues/4652
   ensure-name-substring:
-    skip: true
-    latest: v0.2.4
-    minus1: v0.2.3
+    latest: v0.3.0
+    minus1: v0.2.0
   set-image:
     latest: v0.2.3
     minus1: v0.2.2


### PR DESCRIPTION
# Update e2e function tests

---

## Description
- What changed:
 1. Added the e2e function tests to the nightly tests
 2. Added a retry on each e2e function tests because image pulls often fail. The tests now retry image pulls 3 times and wait 5 seconds between image pulls before failing 
- Why it’s needed: The e2e function tests were not running under CI, they often failed due to failed image pulls, and the `ensure-name-substring` tests were failing due to a bad `ensure-name-substring` function (which is now separately fixed, see https://github.com/kptdev/krm-functions-catalog/pull/1285
- How it works: The tests are added to CI, the retry is added to the test suite, and the `ensure-name-substring` tests are re-enabled in the `function-versions.yaml` file

---

## Related Issue(s)

- Closes/Fixes #1124, #1125

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**
