### PR TITLE
Bugfix DB Cache E2E Tests not actually running with --db-push-drafts-to-git=true flag

### DIFF
--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -29,6 +29,11 @@ export FN_RUNNER_WARM_UP_POD_CACHE ?= true
 # Enable v1alpha2 PackageRevision support (CRD install + controller flag + reconciler)
 export CREATE_V1ALPHA2_RPKG ?= false
 
+# Push draft and proposed package revisions to git when using the DB cache.
+# Must be exported: target-specific assignments only reach the deployment scripts'
+# environment for exported variables.
+export DB_PUSH_DRAFTS_TO_GIT ?= false
+
 # Reconciler configuration
 ALL_RECONCILERS=packagevariants,packagevariantsets,repositories
 ifndef RECONCILERS
@@ -52,6 +57,7 @@ run-in-kind: load-images-to-kind deployment-config deploy-current-config
 run-in-kind-v1alpha2: IMAGE_REPO=porch-kind## Build and deploy porch into a kind cluster with DB cache and v1alpha2 PackageRevision CRD creation
 run-in-kind-v1alpha2: PORCH_CACHE_TYPE=DB
 run-in-kind-v1alpha2: CREATE_V1ALPHA2_RPKG=true
+run-in-kind-v1alpha2: DB_PUSH_DRAFTS_TO_GIT=true
 run-in-kind-v1alpha2: load-images-to-kind deployment-config deploy-current-config
 
 .PHONY: run-in-kind-v1alpha2-no-controller

--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -29,9 +29,7 @@ export FN_RUNNER_WARM_UP_POD_CACHE ?= true
 # Enable v1alpha2 PackageRevision support (CRD install + controller flag + reconciler)
 export CREATE_V1ALPHA2_RPKG ?= false
 
-# Push draft and proposed package revisions to git when using the DB cache.
-# Must be exported: target-specific assignments only reach the deployment scripts'
-# environment for exported variables.
+# Push draft & proposed PR's to git rather than DB only
 export DB_PUSH_DRAFTS_TO_GIT ?= false
 
 # Reconciler configuration

--- a/scripts/create-deployment-blueprint.sh
+++ b/scripts/create-deployment-blueprint.sh
@@ -217,6 +217,15 @@ function enable_db_push_drafts_to_git() {
       --match-name porch-server \
       --match-namespace porch-system \
       -- by-value="--db-push-drafts-to-git=false" put-value="--db-push-drafts-to-git=true"
+
+    # The repository controller builds its own DB cache, which is the one used by the
+    # v1alpha2 PackageRevision path, so it needs the flag flipped separately.
+    kpt fn eval ${DESTINATION} \
+      --image ${SEARCH_REPLACE_IMG} \
+      --match-kind Deployment \
+      --match-name porch-controllers \
+      --match-namespace porch-system \
+      -- by-value="--repositories.push-drafts-to-git=false" put-value="--repositories.push-drafts-to-git=true"
 }
 
 function enable_v1alpha2_packagerevisions() {

--- a/test/e2e/crd/lifecycle_test.go
+++ b/test/e2e/crd/lifecycle_test.go
@@ -197,9 +197,7 @@ var _ = Describe("Lifecycle", Ordered, Label("lifecycle"), func() {
 	})
 
 	// --- Git branch cleanup tests (require push-drafts-to-git=true) ---
-	// These tests auto-skip when push-drafts-to-git is not enabled. For the v1alpha2 path
-	// that is --repositories.push-drafts-to-git=true on the porch-controllers deployment,
-	// which run-in-kind-v1alpha2 does not set.
+	// These tests auto-skip when push-drafts-to-git is not enabled.
 
 	It("should clean up draft git branch when a Draft package is deleted", func() {
 		By("creating a draft package")

--- a/test/e2e/crd/lifecycle_test.go
+++ b/test/e2e/crd/lifecycle_test.go
@@ -197,11 +197,11 @@ var _ = Describe("Lifecycle", Ordered, Label("lifecycle"), func() {
 	})
 
 	// --- Git branch cleanup tests (require push-drafts-to-git=true) ---
-	// These tests auto-skip when push-drafts-to-git is not enabled.
-	// Known gap: dbPackageRevision.Delete only calls git delete for Published
-	// packages. Draft/proposed branches are not cleaned up. Tracked as Issue 36.
+	// These tests auto-skip when push-drafts-to-git is not enabled. For the v1alpha2 path
+	// that is --repositories.push-drafts-to-git=true on the porch-controllers deployment,
+	// which run-in-kind-v1alpha2 does not set.
 
-	PIt("should clean up draft git branch when a Draft package is deleted", func() {
+	It("should clean up draft git branch when a Draft package is deleted", func() {
 		By("creating a draft package")
 		pr := newPackageRevision(env.Namespace, env.RepoName, "del-draft-br", "v1", withInit("draft branch cleanup"))
 		Expect(k8sClient.Create(env.Ctx, pr)).To(Succeed())
@@ -225,7 +225,7 @@ var _ = Describe("Lifecycle", Ordered, Label("lifecycle"), func() {
 		}).WithTimeout(defaultTimeout).Should(Not(ContainElement(ContainSubstring("del-draft-br"))))
 	})
 
-	PIt("should clean up proposed git branch when a Proposed package is deleted", func() {
+	It("should clean up proposed git branch when a Proposed package is deleted", func() {
 		By("creating and proposing a package")
 		pr := newPackageRevision(env.Namespace, env.RepoName, "del-prop-br", "v1", withInit("proposed branch cleanup"))
 		Expect(k8sClient.Create(env.Ctx, pr)).To(Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

<!-- Short, descriptive title for the PR -->
Bugfix DB Cache E2E Tests not actually running with --db-push-drafts-to-git=true flag

---

## NOTE PLEASE BE AWARE THE 2 PRS BELOW MUST BE MERGED IN BEFORE THIS ONE. E2E TESTS WILL FAIL UNTIL THOSE FIXES ARE IN
- #1136 
- #1141 

---

## Description
<!-- Describe what this PR does and why -->
- What changed: make target variable exporting + enabled skipped crd test
- Why it’s needed: right now tests are using make targets which are intended to have `--db-push-drafts-to-git=true` flag but is in fact `false`
- How it works: exporting make target variable so that its actually used by E2E Tests + enabling previously skipped crd tests

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes #1140 

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [ ] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. 
2. 
3. 

---

## Additional Notes (Optional)
- Known issues: 
- Further improvements: 
- Review notes: 

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro just for a bit of understanding on the test cases
