### PR TITLE
Docs: Add versioning section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ project as of December 2023.
 
 Documentation of Porch is available in the [Porch documentation page](https://porch.kpt.dev/).
 
+## Versioning
+
+This project follows the [kpt project versioning guidelines](https://github.com/kptdev/governance/blob/main/VERSIONING.md).
+
 ## License compliance
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkptdev%2Fporch.svg?type=large&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkptdev%2Fporch?ref=badge_large&issueType=license)


### PR DESCRIPTION
 ## Description
  - **What changed:** Added a Versioning section to `README.md` referencing the shared governance `VERSIONING.md`.
  - **Why it's needed:** The community agreed (kptdev/kpt#4621, kptdev/kpt#4610) to maintain a common versioning strategy in the governance repo and reference it from all project repositories. `krm-functions-catalog`, `krm-functions-sdk`, and `kpt` already reference it. porch was the only repo missing this.

  ## Related Issue(s)

  - Relates to kptdev/kpt#4621

  ## Type of Change

  - [x] Documentation

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [x] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to check versioning references across all kpt project repos and draft the change/PR Message.