### PR TITLE
#1148 - Fetch secret from cluster instead of cache on every api request

### DIFF
--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -1100,9 +1100,6 @@ func (r *gitRepository) getAuthMethod(ctx context.Context) (transport.AuthMethod
 		return nil, nil
 	}
 
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
 	cred, err := r.credentialResolver.ResolveCredential(ctx, r.Key().Namespace, r.secret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to obtain credential from secret %s/%s: %w", r.Key().Namespace, r.secret, err)

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -257,10 +257,6 @@ type gitRepository struct {
 	// TODO: Better caching here, support repository spec changes
 	deployment bool
 
-	// credential contains the information needed to authenticate against
-	// a git repository.
-	credential repository.Credential
-
 	// deletionProposedCache contains the deletionProposed branches that
 	// exist in the repo so that we can easily check them without iterating
 	// through all the refs each time
@@ -1095,9 +1091,10 @@ func (r *gitRepository) dumpAllRefs() {
 	}
 }
 
-// getAuthMethod fetches the credentials for authenticating to git. It caches the
-// credentials between calls and refresh credentials when the tokens have expired.
-func (r *gitRepository) getAuthMethod(ctx context.Context, forceRefresh bool) (transport.AuthMethod, error) {
+// getAuthMethod fetches the credentials for authenticating to git.
+// The secret is re-read on every call to ensure changes to secret
+// data are picked up promptly.
+func (r *gitRepository) getAuthMethod(ctx context.Context) (transport.AuthMethod, error) {
 	// If no secret is provided, we try without any auth.
 	if r.secret == "" {
 		return nil, nil
@@ -1106,15 +1103,12 @@ func (r *gitRepository) getAuthMethod(ctx context.Context, forceRefresh bool) (t
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	if r.credential == nil || !r.credential.Valid() || forceRefresh {
-		if cred, err := r.credentialResolver.ResolveCredential(ctx, r.Key().Namespace, r.secret); err != nil {
-			return nil, fmt.Errorf("failed to obtain credential from secret %s/%s: %w", r.Key().Namespace, r.secret, err)
-		} else {
-			r.credential = cred
-		}
+	cred, err := r.credentialResolver.ResolveCredential(ctx, r.Key().Namespace, r.secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain credential from secret %s/%s: %w", r.Key().Namespace, r.secret, err)
 	}
 
-	return r.credential.ToAuthMethod(), nil
+	return cred.ToAuthMethod(), nil
 }
 
 func (r *gitRepository) GetRepo() (string, error) {
@@ -1969,27 +1963,15 @@ func (r *gitRepository) ClosePackageRevisionDraft(ctx context.Context, prd repos
 	}, nil
 }
 
-// doGitWithAuth fetches auth information for git and provides it
-// to the provided function which performs the operation against a git repo.
+// doGitWithAuth fetches auth credentials and provides them to the
+// operation. Retries are handled by the outer retry loop (e.g.
+// fetchRemoteRepositoryWithRetry, pushAndCleanup).
 func (r *gitRepository) doGitWithAuth(ctx context.Context, op func(transport.AuthMethod) error) error {
-	auth, err := r.getAuthMethod(ctx, false)
+	auth, err := r.getAuthMethod(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to obtain git credentials: %w", err)
 	}
-	err = op(auth)
-	if err != nil {
-		if !pkgerrors.Is(err, transport.ErrAuthenticationRequired) {
-			return err
-		}
-		klog.Infof("Authentication failed. Trying to refresh credentials")
-		// TODO: Consider having some kind of backoff here.
-		auth, err := r.getAuthMethod(ctx, true)
-		if err != nil {
-			return fmt.Errorf("failed to obtain git credentials: %w", err)
-		}
-		return op(auth)
-	}
-	return nil
+	return op(auth)
 }
 
 // findPackage finds the packages in the git repository, under commit, if it is exists at path.

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -2663,7 +2663,10 @@ func TestGetAuthMethod_PicksUpSecretChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	basicAuth := auth.(*http.BasicAuth)
+	basicAuth, ok := auth.(*http.BasicAuth)
+	if !ok {
+		t.Fatalf("expected *http.BasicAuth, got %T", auth)
+	}
 	if basicAuth.Username != "user1" {
 		t.Fatalf("expected user1, got %s", basicAuth.Username)
 	}
@@ -2676,7 +2679,10 @@ func TestGetAuthMethod_PicksUpSecretChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	basicAuth = auth.(*http.BasicAuth)
+	basicAuth, ok = auth.(*http.BasicAuth)
+	if !ok {
+		t.Fatalf("expected *http.BasicAuth after secret change, got %T", auth)
+	}
 	if basicAuth.Username != "user2" {
 		t.Fatalf("expected user2 after secret change, got %s", basicAuth.Username)
 	}

--- a/pkg/externalrepo/git/git_test.go
+++ b/pkg/externalrepo/git/git_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,6 +31,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/google/go-cmp/cmp"
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	configapi "github.com/kptdev/porch/api/porchconfig/v1alpha1"
@@ -2557,5 +2560,187 @@ func TestAppendRetryableErrors(t *testing.T) {
 				assert.Equal(t, want, got, "Pattern %d", i)
 			}
 		})
+	}
+}
+
+// --- getAuthMethod tests ---
+
+// testCredential is a simple credential for testing getAuthMethod.
+type testCredential struct {
+	username string
+	password string
+}
+
+func (c *testCredential) Valid() bool { return true }
+func (c *testCredential) ToAuthMethod() transport.AuthMethod {
+	return &http.BasicAuth{Username: c.username, Password: c.password}
+}
+func (c *testCredential) ToString() string { return c.username }
+
+// mutableCredentialResolver allows changing the returned credential between calls.
+type mutableCredentialResolver struct {
+	mu       sync.Mutex
+	username string
+	password string
+	calls    int
+}
+
+func (r *mutableCredentialResolver) ResolveCredential(_ context.Context, _, _ string) (repository.Credential, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	return &testCredential{username: r.username, password: r.password}, nil
+}
+
+func (r *mutableCredentialResolver) setCredentials(username, password string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.username = username
+	r.password = password
+}
+
+func (r *mutableCredentialResolver) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+// failingCredentialResolver returns an error on resolve.
+type failingCredentialResolver struct{}
+
+func (r *failingCredentialResolver) ResolveCredential(_ context.Context, _, _ string) (repository.Credential, error) {
+	return nil, fmt.Errorf("secret not found")
+}
+
+func newTestGitRepo(secret string, resolver repository.CredentialResolver) *gitRepository {
+	return &gitRepository{
+		key: repository.RepositoryKey{
+			Name:      "test-repo",
+			Namespace: "test-ns",
+		},
+		secret:             secret,
+		credentialResolver: resolver,
+	}
+}
+
+func TestGetAuthMethod_NoSecret(t *testing.T) {
+	repo := newTestGitRepo("", nil)
+
+	auth, err := repo.getAuthMethod(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if auth != nil {
+		t.Fatalf("expected nil auth for no secret, got %v", auth)
+	}
+}
+
+func TestGetAuthMethod_ReturnsCredentials(t *testing.T) {
+	resolver := &mutableCredentialResolver{username: "user1", password: "pass1"}
+	repo := newTestGitRepo("my-secret", resolver)
+
+	auth, err := repo.getAuthMethod(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	basicAuth, ok := auth.(*http.BasicAuth)
+	if !ok {
+		t.Fatalf("expected *http.BasicAuth, got %T", auth)
+	}
+	if basicAuth.Username != "user1" || basicAuth.Password != "pass1" {
+		t.Fatalf("expected user1/pass1, got %s/%s", basicAuth.Username, basicAuth.Password)
+	}
+}
+
+func TestGetAuthMethod_PicksUpSecretChanges(t *testing.T) {
+	resolver := &mutableCredentialResolver{username: "user1", password: "pass1"}
+	repo := newTestGitRepo("my-secret", resolver)
+	ctx := context.Background()
+
+	// First call: returns user1
+	auth, err := repo.getAuthMethod(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	basicAuth := auth.(*http.BasicAuth)
+	if basicAuth.Username != "user1" {
+		t.Fatalf("expected user1, got %s", basicAuth.Username)
+	}
+
+	// Simulate secret update: change to user2
+	resolver.setCredentials("user2", "pass2")
+
+	// Second call: should return user2 immediately (no auth failure needed)
+	auth, err = repo.getAuthMethod(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	basicAuth = auth.(*http.BasicAuth)
+	if basicAuth.Username != "user2" {
+		t.Fatalf("expected user2 after secret change, got %s", basicAuth.Username)
+	}
+}
+
+func TestGetAuthMethod_AlwaysCallsResolver(t *testing.T) {
+	resolver := &mutableCredentialResolver{username: "user1", password: "pass1"}
+	repo := newTestGitRepo("my-secret", resolver)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		_, err := repo.getAuthMethod(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error on call %d: %v", i, err)
+		}
+	}
+
+	if got := resolver.callCount(); got != 5 {
+		t.Fatalf("expected resolver to be called 5 times, got %d", got)
+	}
+}
+
+func TestGetAuthMethod_ResolverError(t *testing.T) {
+	repo := newTestGitRepo("my-secret", &failingCredentialResolver{})
+
+	_, err := repo.getAuthMethod(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := err.Error(); got != "failed to obtain credential from secret test-ns/my-secret: secret not found" {
+		t.Fatalf("unexpected error message: %s", got)
+	}
+}
+
+func TestGetAuthMethod_ConcurrentAccess(t *testing.T) {
+	resolver := &mutableCredentialResolver{username: "user1", password: "pass1"}
+	repo := newTestGitRepo("my-secret", resolver)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			auth, err := repo.getAuthMethod(ctx)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if auth == nil {
+				errs <- fmt.Errorf("got nil auth")
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent access error: %v", err)
+	}
+
+	if got := resolver.callCount(); got != 100 {
+		t.Fatalf("expected 100 resolver calls, got %d", got)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

<!-- Short, descriptive title for the PR -->
# Fetch secret from cluster instead of cache on every api request

---

## Description
<!-- Describe what this PR does and why -->
- What changed: 
getAuthMethod now re-reads the repository Secret from the Kubernetes API on every git operation instead of caching it indefinitely. The credential field, forceRefresh parameter, and inner auth-retry in doGitWithAuth were removed as they became redundant.

- Why it’s needed: 
Previously, when a user updated a repository Secret (e.g., switching from gitea_user1 to gitea_user2), neither porch-server nor porch-controller would pick up the change unless authentication failed first. If the old credentials still worked, the new ones were never used. For correctness and security, we need to always have the latest secret data.

- How it works: 
Each git operation calls ResolveCredential, which does a single client.Get on the Secret — a lightweight K8s API call (<1s usually 5-10ms) that's negligible compared to the git network operation it precedes. The outer retry loops (fetchRemoteRepositoryWithRetry, pushAndCleanup) handle transient failures, and each retry gets fresh credentials automatically.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes # https://github.com/kptdev/porch/issues/1148

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [x] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. 
2. 
3. 

---

## Additional Notes (Optional)
- Known issues: 
- Further improvements: 
- Review notes: 

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

Kiro 
