### PR TITLE
Fix `make run-in-kind` by upgrading KRM function versions in Dockerfile

### DIFF
--- a/func/Dockerfile
+++ b/func/Dockerfile
@@ -17,16 +17,16 @@ ARG GOLANG_ALPINE_VERSION=latest
 ARG PORCH_GHCR_PREFIX_URL=ghcr.io/kptdev/krm-functions-catalog
 ARG DOCKERHUB_MIRROR=docker.io
 
-FROM ${PORCH_GHCR_PREFIX_URL}/apply-setters:v0.2.4 AS apply-setters
+FROM ${PORCH_GHCR_PREFIX_URL}/apply-setters:v0.3.0 AS apply-setters
 FROM ${PORCH_GHCR_PREFIX_URL}/ensure-name-substring:v0.3.0 AS ensure-name-substring
-FROM ${PORCH_GHCR_PREFIX_URL}/search-replace:v0.2.3 AS search-replace
-FROM ${PORCH_GHCR_PREFIX_URL}/set-annotations:v0.1.7 AS set-annotations
-FROM ${PORCH_GHCR_PREFIX_URL}/set-image:v0.2.2 AS set-image
-FROM ${PORCH_GHCR_PREFIX_URL}/set-labels:v0.2.4 AS set-labels
-FROM ${PORCH_GHCR_PREFIX_URL}/set-namespace:v0.4.5 AS set-namespace
+FROM ${PORCH_GHCR_PREFIX_URL}/search-replace:v0.2.4 AS search-replace
+FROM ${PORCH_GHCR_PREFIX_URL}/set-annotations:v0.1.8 AS set-annotations
+FROM ${PORCH_GHCR_PREFIX_URL}/set-image:v0.2.3 AS set-image
+FROM ${PORCH_GHCR_PREFIX_URL}/set-labels:v0.2.5 AS set-labels
+FROM ${PORCH_GHCR_PREFIX_URL}/set-namespace:v0.4.6 AS set-namespace
 FROM ${PORCH_GHCR_PREFIX_URL}/set-project-id:v0.2.1 AS set-project-id
-FROM ${PORCH_GHCR_PREFIX_URL}/starlark:v0.5.5 AS starlark
-FROM ${PORCH_GHCR_PREFIX_URL}/upsert-resource:v0.2.3 AS upsert-resource
+FROM ${PORCH_GHCR_PREFIX_URL}/starlark:v0.5.6 AS starlark
+FROM ${PORCH_GHCR_PREFIX_URL}/upsert-resource:v0.2.4 AS upsert-resource
 
 
 FROM ${DOCKERHUB_MIRROR}/golang:${GOLANG_ALPINE_VERSION} AS builder

--- a/func/Dockerfile
+++ b/func/Dockerfile
@@ -18,7 +18,7 @@ ARG PORCH_GHCR_PREFIX_URL=ghcr.io/kptdev/krm-functions-catalog
 ARG DOCKERHUB_MIRROR=docker.io
 
 FROM ${PORCH_GHCR_PREFIX_URL}/apply-setters:v0.2.4 AS apply-setters
-FROM ${PORCH_GHCR_PREFIX_URL}/ensure-name-substring:v0.2.1 AS ensure-name-substring
+FROM ${PORCH_GHCR_PREFIX_URL}/ensure-name-substring:v0.3.0 AS ensure-name-substring
 FROM ${PORCH_GHCR_PREFIX_URL}/search-replace:v0.2.3 AS search-replace
 FROM ${PORCH_GHCR_PREFIX_URL}/set-annotations:v0.1.7 AS set-annotations
 FROM ${PORCH_GHCR_PREFIX_URL}/set-image:v0.2.2 AS set-image

--- a/func/Dockerfile
+++ b/func/Dockerfile
@@ -24,7 +24,6 @@ FROM ${PORCH_GHCR_PREFIX_URL}/set-annotations:v0.1.8 AS set-annotations
 FROM ${PORCH_GHCR_PREFIX_URL}/set-image:v0.2.3 AS set-image
 FROM ${PORCH_GHCR_PREFIX_URL}/set-labels:v0.2.5 AS set-labels
 FROM ${PORCH_GHCR_PREFIX_URL}/set-namespace:v0.4.6 AS set-namespace
-FROM ${PORCH_GHCR_PREFIX_URL}/set-project-id:v0.2.1 AS set-project-id
 FROM ${PORCH_GHCR_PREFIX_URL}/starlark:v0.5.6 AS starlark
 FROM ${PORCH_GHCR_PREFIX_URL}/upsert-resource:v0.2.4 AS upsert-resource
 
@@ -61,7 +60,6 @@ COPY --from=set-annotations        --chown=root:root --chmod=555 /usr/local/bin/
 COPY --from=set-image              --chown=root:root --chmod=555 /usr/local/bin/function /home/nonroot/functions/set-image
 COPY --from=set-labels             --chown=root:root --chmod=555 /usr/local/bin/function /home/nonroot/functions/set-labels
 COPY --from=set-namespace          --chown=root:root --chmod=555 /usr/local/bin/function /home/nonroot/functions/set-namespace
-COPY --from=set-project-id         --chown=root:root --chmod=555 /usr/local/bin/function /home/nonroot/functions/set-project-id
 COPY --from=starlark               --chown=root:root --chmod=555 /usr/local/bin/function /home/nonroot/functions/starlark
 COPY --from=upsert-resource        --chown=root:root --chmod=555 /usr/local/bin/function /home/nonroot/functions/upsert-resource
 


### PR DESCRIPTION
# Fix make run-in-kind by upgrading KRM function versions in Dockerfile

---

## Description
<!-- Describe what this PR does and why -->
- What changed: The krm function versions are upgraded in the function Dockerfile
- Why it’s needed: The `make run-in-kind` target was failing
- How it works: The correct KRM function versions are specified

---

## Related Issue(s)
- Closes/Fixes #

---

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## AI Disclosure

- [ ] **I have used AI in the creation of this PR.**
