### PR TITLE
Fix flaky CR-cache E2E teardown: drain orphaned PackageRev CRs

### DIFF
--- a/test/e2e/suiteutils/suite_utils.go
+++ b/test/e2e/suiteutils/suite_utils.go
@@ -638,10 +638,8 @@ func (t *TestSuite) WaitUntilAllPackageRevsDeleted(repoName string, namespace st
 		}
 		if len(internalPkgRevList.Items) > 0 {
 			t.Logf("Found %d PackageRevs from repo %s", len(internalPkgRevList.Items), repoName)
-			for _, internalPkgRev := range internalPkgRevList.Items {
-				if len(internalPkgRev.Finalizers) > 0 {
-					t.removePkgRevFinalizers(ctx, &internalPkgRev)
-				}
+			for i := range internalPkgRevList.Items {
+				t.forceDeletePkgRev(ctx, &internalPkgRevList.Items[i])
 			}
 			return false, nil
 		}
@@ -1074,23 +1072,40 @@ func RunInParallel(functions ...func() any) []any {
 	return results
 }
 
-func (t *TestSuite) removePkgRevFinalizers(ctx context.Context, pkgRev *configapi.PackageRev) {
-	t.Logf("removing finalizers from orphaned PackageRev %s/%s", pkgRev.Namespace, pkgRev.Name)
-	pkgRev.Finalizers = []string{}
+// forceDeletePkgRev drains an orphaned internal PackageRev CR by deleting it and
+// clearing any finalizers. Idempotent; called each teardown poll until gone.
+func (t *TestSuite) forceDeletePkgRev(ctx context.Context, pkgRev *configapi.PackageRev) {
+	key := client.ObjectKeyFromObject(pkgRev)
+
+	// Issue the delete first so a deletionTimestamp is set even if the object
+	// currently has no finalizers.
+	if err := t.Client.Delete(ctx, pkgRev); err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("failed to delete orphaned PackageRev %s/%s: %v", pkgRev.Namespace, pkgRev.Name, err)
+	}
+
+	// Clear finalizers so the pending deletion can complete. Retry on conflict
+	// with a fresh read, since the object may be updated concurrently.
 	for range 3 {
+		if len(pkgRev.Finalizers) == 0 {
+			return
+		}
+		t.Logf("clearing finalizers from orphaned PackageRev %s/%s", pkgRev.Namespace, pkgRev.Name)
+		pkgRev.Finalizers = []string{}
 		if err := t.Client.Update(ctx, pkgRev); err != nil {
+			if apierrors.IsNotFound(err) {
+				return
+			}
 			if apierrors.IsConflict(err) {
-				key := client.ObjectKeyFromObject(pkgRev)
 				if getErr := t.Client.Get(ctx, key, pkgRev); getErr != nil {
 					if apierrors.IsNotFound(getErr) {
 						return
 					}
 					continue
 				}
-				pkgRev.Finalizers = []string{}
 				continue
 			}
-			t.Logf("failed to remove finalizers from PackageRev %s/%s: %v", pkgRev.Namespace, pkgRev.Name, err)
+			t.Logf("failed to clear finalizers from PackageRev %s/%s: %v", pkgRev.Namespace, pkgRev.Name, err)
+			return
 		}
 		return
 	}


### PR DESCRIPTION
## Description

- What changed: `WaitUntilAllPackageRevsDeleted` now force-drains leftover internal `PackageRev` CRs on every poll iteration. Replaced `removePkgRevFinalizers` with `forceDeletePkgRev`, which issues a delete then clears finalizers (with conflict-retry).

- Why it’s needed: The nightly "E2E Tests (CR Cache)" job failed every run with `FATAL: PackageRevs from repo <x> still remain`. After a repository is deleted, orphaned internal PackageRev CRs are left behind with no controller to drain them. The old helper only cleared finalizers when present and never issued a delete, so an orphan with no deletionTimestamp was never removed. The poll then spun until the 60s timeout and FATAL'd, failing whichever test owned that repo.

- How it works: Deleting first sets a deletionTimestamp even when no finalizers exist; clearing finalizers then lets the deletion complete. Running every iteration ensures the poll retries until the CRs actually drain to zero.

---

## Related Issue(s)

- Closes/Fixes #

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [ ] All tests and gating checks pass

---

## Testing Instructions (Optional)

1. Run the CR-cache E2E suite (`make test-e2e` against a CR-cache deployment).
2. Confirm `TestBasicLifecycle` / `TestPackageRevisionMetadata` teardown no longer FATALs with "PackageRevs from repo ... still remain".

---

## Additional Notes (Optional)

- Known issues: If orphaned CRs are stuck Terminating on a finalizer re-added by the CR cache, this test-side drain may still not clear them; that would point to a controller-side issue in the repository deletion path.
- Review notes: No repository-controller behaviour changed — fix is confined to the E2E suite helper.

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:

  - Kiro to analyse the failing CI runs and server/controller logs, identify the root cause, and implement the test helper fix.