### PR TITLE
access/update a single file via the prr api

### DIFF
--- a/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
+++ b/controllers/repositories/pkg/controllers/repository/pkgrevsync_test.go
@@ -25,6 +25,7 @@ import (
 	porchv1alpha2 "github.com/kptdev/porch/api/porch/v1alpha2"
 	configapi "github.com/kptdev/porch/api/porchconfig/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -121,6 +122,9 @@ func (f *fakePackageRevision) GetResources(_ context.Context) (*porchv1alpha1.Pa
 		}, nil
 	}
 	return nil, nil
+}
+func (f *fakePackageRevision) GetFilteredResources(ctx context.Context, _ selector.PRRGet) (*porchv1alpha1.PackageRevisionResources, error) {
+	return f.GetResources(ctx)
 }
 func (f *fakePackageRevision) GetUpstreamLock(_ context.Context) (kptfilev1.Upstream, kptfilev1.Locator, error) {
 	return kptfilev1.Upstream{}, f.upstreamLock, nil

--- a/docs/content/en/docs/11_glossary/_index.md
+++ b/docs/content/en/docs/11_glossary/_index.md
@@ -39,7 +39,7 @@ A Kubernetes custom resource representing a specific revision of a package with 
 
 ### PackageRevisionResources
 
-A Kubernetes custom resource containing the actual file contents of a package revision. It stores KRM resources as key-value pairs (filename → content). This resource is always paired with a PackageRevision resource.
+A Kubernetes custom resource containing the actual file contents of a package revision. It stores KRM resources as key-value pairs (filename → content). This resource is always paired with a PackageRevision resource. Clients can GET a subset of files with the `file` query parameter and UPDATE a subset of files with `partial=true` so omitted files are kept.
 
 *See also*: [PackageRevision](#packagerevision)
 

--- a/docs/content/en/docs/2_concepts/package.md
+++ b/docs/content/en/docs/2_concepts/package.md
@@ -26,7 +26,8 @@ resource:
 - **PackageRevision**: A Kubernetes resource containing the kpt package metadata (name, repository, revision number, lifecycle
   stage, workspace, task list)
 - **PackageRevisionResources**: A companion resource containing the actual kpt package contents, represented as a key-value
-  map of file names to YAML file contents
+  map of file names to YAML file contents. You can [read a subset of files]({{% relref "/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md#reading-selected-package-files" %}})
+  or [update selected files without replacing the rest of the package]({{% relref "/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md#partial-package-content-updates" %}}).
 
 These resources expose [kpt packages](https://kpt.dev/book/03-packages/), stored in Git repositories, as Kubernetes-native
 objects.

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_crd_based_packagerevisions/creating-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_crd_based_packagerevisions/creating-packages.md
@@ -71,7 +71,9 @@ kubectl get packagerevisionresources my-repo-my-package-v1 -o yaml > prr.yaml
 kubectl apply -f prr.yaml
 ```
 
-After pushing content, the API Server patches the `porch.kpt.dev/render-request` annotation on the PackageRevision CRD. This triggers the PR Controller to render the updated content.
+A complete apply **replaces** the package with `spec.resources`. To change selected files and keep the rest, GET those files with `?file=`, edit them, set `metadata.name` to `<name>?partial=true`, and replace. See [Reading Selected Package Files]({{% relref "/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md#reading-selected-package-files" %}}) and [Partial Package Content Updates]({{% relref "/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md#partial-package-content-updates" %}}).
+
+After pushing content, the API Server patches the `porch.kpt.dev/render-request` annotation on the PackageRevision CRD. This triggers the PR Controller to render the updated content. Partial updates still write the merged package and trigger the same render path.
 
 ## Observe Rendering
 
@@ -179,7 +181,7 @@ Validating admission webhooks for PackageRevision are not yet implemented. The o
 | Create (init) | `kubectl apply` with `spec.source.init` |
 | Create (clone) | `kubectl apply` with `spec.source.cloneFrom` |
 | Create (copy) | `kubectl apply` with `spec.source.copyFrom` |
-| Push content | Edit and apply `PackageRevisionResources` |
+| Push content | Edit and apply `PackageRevisionResources` (use `?partial=true` to merge selected files) |
 | Check status | `kubectl get packagerevision -o jsonpath='{.status.conditions}'` |
 | Publish | Patch `spec.lifecycle` to `Published` |
 | Delete draft | `kubectl delete packagerevision` |

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_crd_based_packagerevisions/differences.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_crd_based_packagerevisions/differences.md
@@ -95,7 +95,7 @@ The `spec.lifecycle` field is the same in both architectures (Draft, Proposed, P
 
 ## Content Access (PRR)
 
-`PackageRevisionResources` **remains an aggregated API** served by the Porch API Server — it is the **only component that does not become a native CRD** in the v1alpha2 architecture. You read and write package content the same way regardless of which architecture manages the PackageRevision.
+`PackageRevisionResources` **remains an aggregated API** served by the Porch API Server — it is the **only component that does not become a native CRD** in the v1alpha2 architecture. You read and write package content the same way regardless of which architecture manages the PackageRevision, including filtered GET (`?file=<path>`) and partial UPDATE (`?partial=true`). See [Reading Selected Package Files]({{% relref "/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md#reading-selected-package-files" %}}) and [Partial Package Content Updates]({{% relref "/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md#partial-package-content-updates" %}}).
 
 This design choice allows content access to bypass etcd's object size limits (which PRR can exceed), while keeping the PackageRevision metadata as a native CRD.
 

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/_index.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/_index.md
@@ -86,6 +86,8 @@ PackageRevisions contain structured configuration files that can be modified thr
 
 KRM functions defined in the Kptfile automatically transform resources; they run when PackageRevisions are pushed to Porch. Common examples include `set-namespace`, `apply-replacements`, and `search-replace`.
 
+You can also read or update selected files through `PackageRevisionResources` without pulling the whole package. See [Reading Selected Package Files]({{% relref "inspecting-packages.md#reading-selected-package-files" %}}) and [Partial Package Content Updates]({{% relref "inspecting-packages.md#partial-package-content-updates" %}}).
+
 {{% alert title="Note" color="primary" %}}
 When specifying a function image in the Kptfile pipeline, you can use the shorthand form (e.g. `set-namespace:latest`) without a full container registry path. Porch will automatically resolve it using the default registry prefix configured in the Function Runner. You can also use the full image path (e.g. `ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest`) if you prefer to be explicit. To see which functions are available, run `kubectl get functionconfigs -n porch-fn-system`.
 {{% /alert %}}

--- a/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md
+++ b/docs/content/en/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md
@@ -204,6 +204,68 @@ items:
 
 ---
 
+### Reading Selected Package Files
+
+`PackageRevisionResources` can return a subset of files instead of the whole package. Append `file=<path>` to the resource name. Repeat the parameter for each path. Omit `file` to return every file.
+
+Quote the name so the shell does not treat `?` as a glob:
+
+```bash
+kubectl get packagerevisionresources 'porch-test.my-first-package.v1?file=Kptfile' \
+  --namespace default -o yaml
+```
+
+Multiple files:
+
+```bash
+kubectl get packagerevisionresources \
+  'porch-test.my-first-package.v1?file=Kptfile&file=package-context.yaml' \
+  --namespace default -o yaml
+```
+
+The response `spec.resources` map contains only the requested files that exist in the package. Unknown paths are omitted, so a request for only missing files returns an empty `spec.resources` map.
+
+{{% alert title="Note" color="primary" %}}
+The `file` selector is part of the resource **name** (`<name>?file=Kptfile`), not a kubectl `--field-selector`. Kubernetes aggregated GET handlers receive the path name only, so Porch parses the query string from that name.
+{{% /alert %}}
+
+To display only the root Kptfile with `porchctl`, use `--show-kptfile` (see [Viewing the Root Kptfile](#viewing-the-root-kptfile)).
+
+---
+
+### Partial Package Content Updates
+
+By default, an update of `PackageRevisionResources` **replaces** the entire package with `spec.resources`. Files omitted from the request are deleted.
+
+To change selected files and keep the rest of the package, append `partial=true` to the resource name. Submitted keys overwrite or add files; keys that are not in the request are left unchanged. Updates still apply only to Draft package revisions and still run the render pipeline on the merged package.
+
+Accepted `partial` values: `true`, `yes`, `1`, or empty (`?partial` or `?partial=true`). Multiple `partial` values in one request are rejected.
+
+```bash
+# Fetch only the Kptfile
+kubectl get packagerevisionresources 'porch-test.my-first-package.v1?file=Kptfile' \
+  --namespace default -o yaml > kptfile.yaml
+```
+
+Edit `spec.resources.Kptfile` in `kptfile.yaml`. Then set `metadata.name` so the update is partial (the GET response uses the bare package revision name):
+
+```yaml
+metadata:
+  name: porch-test.my-first-package.v1?partial=true
+```
+
+```bash
+kubectl replace -f kptfile.yaml
+```
+
+A following GET without `file` returns the complete merged package. `porchctl rpkg push` still uploads a full local directory and is a complete replace.
+
+{{% alert title="Warning" color="warning" %}}
+If you omit `?partial=true` and apply a `PackageRevisionResources` object that contains only some files, Porch replaces the stored package with those files only.
+{{% /alert %}}
+
+---
+
 ## Advanced Filtering
 
 Porch provides multiple ways to filter PackageRevisions. You can either use `porchctl`'s built-in flags, Kubernetes label selectors, or field selectors depending on your needs.

--- a/docs/content/en/docs/5_architecture_and_components/controllers/packagerevision-controller/functionality/rendering.md
+++ b/docs/content/en/docs/5_architecture_and_components/controllers/packagerevision-controller/functionality/rendering.md
@@ -14,7 +14,7 @@ Rendering runs the KRM function pipeline defined in the package's Kptfile. The c
 
 Two events can trigger rendering:
 
-1. **Content push via PRR**: When a user edits `PackageRevisionResources`, the API Server patches the `porch.kpt.dev/render-request` annotation on the PackageRevision CRD. The controller's predicate filter detects this and triggers a reconcile.
+1. **Content push via PRR**: When a user edits `PackageRevisionResources` (complete replace or `?partial=true` merge), the API Server writes the resulting package and patches the `porch.kpt.dev/render-request` annotation on the PackageRevision CRD. The controller's predicate filter detects this and triggers a reconcile.
 2. **Source execution completion**: After init, clone, copy, or upgrade produces initial content (including a generated or copied Kptfile), the controller immediately proceeds to render. For init with an empty Kptfile, rendering may produce no additional output.
 
 The controller tracks the annotation value in `status.observedPrrResourceVersion` to avoid re-rendering the same content.

--- a/docs/content/en/docs/5_architecture_and_components/controllers/packagerevision-controller/interactions.md
+++ b/docs/content/en/docs/5_architecture_and_components/controllers/packagerevision-controller/interactions.md
@@ -98,7 +98,7 @@ When the user later patches `spec.lifecycle` to Published, the controller calls 
 
 ## Data Flow: Pushing Content and Rendering
 
-A user edits package content through `PackageRevisionResources`. The API Server writes the new content to the cache via the Engine, then patches the render-request annotation on the PackageRevision CRD.
+A user edits package content through `PackageRevisionResources` (complete replace, or a partial merge with `?partial=true`). The API Server writes the new content to the cache via the Engine, then patches the render-request annotation on the PackageRevision CRD.
 
 The annotation change triggers a reconcile. Source is skipped (already done). The controller enters `reconcileRender`, sees that the annotation value differs from `status.observedPrrResourceVersion`, and proceeds to render.
 

--- a/docs/content/en/docs/5_architecture_and_components/engine/functionality/task-coordination.md
+++ b/docs/content/en/docs/5_architecture_and_components/engine/functionality/task-coordination.md
@@ -244,15 +244,16 @@ UpdatePackageResources
 
 **Process:**
 1. **Engine opens draft** from existing package revision
-2. **Engine invokes DoPRResourceMutations** with:
+2. **Engine merges resources** when the update is partial (`?partial=true`): files from the existing package that are not in the request are kept; submitted files overwrite or add keys
+3. **Engine invokes DoPRResourceMutations** with:
    - Package revision (for context)
    - Draft to modify
    - Old PackageRevisionResources
    - New PackageRevisionResources
-3. **Task Handler updates** package resources in draft
-4. **Task Handler executes render** (runs function pipeline)
-5. **Task Handler returns** RenderStatus with function results
-6. **Engine closes draft** without lifecycle change
+4. **Task Handler updates** package resources in draft
+5. **Task Handler executes render** (runs function pipeline)
+6. **Task Handler returns** RenderStatus with function results
+7. **Engine closes draft** without lifecycle change
 
 ### DoPRResourceMutations Parameters
 

--- a/docs/content/en/docs/5_architecture_and_components/porch-apiserver/functionality.md
+++ b/docs/content/en/docs/5_architecture_and_components/porch-apiserver/functionality.md
@@ -57,11 +57,17 @@ The storage of PackageRevisions is also delegated to the Engine; there is no dir
 ### PackageRevisionResources Storage
 
 **Operations:**
-- **Get**: Retrieves package content via Engine
+- **Get**: Retrieves package content via Engine. Optional `file` query parameters select which files to return; omitting them returns the full package.
 - **List**: Lists resources for package revisions
-- **Update**: Updates package content via Engine
+- **Update**: Updates package content via Engine. With `partial=true`, submitted files are merged into the existing package; without it, `spec.resources` replaces the whole package.
 
 Package contents are handled by storing resources as a map where each filename is associated with its content. This design supports large package content, bypassing limitations that might be imposed by etcd. Furthermore, any updates to this content automatically trigger the execution of the render pipeline, and the system provides a RenderStatus along with the function results.
+
+Selectors are parsed from the resource name in the request (`<name>?file=Kptfile` or `<name>?partial=true`) because the Kubernetes aggregated GET/UPDATE handlers receive the path name, not a separate query object. Quote the name in the shell so `?` is not treated as a glob.
+
+**Get file filter:** Repeat `file` for each path (`?file=Kptfile&file=README.md`). The response `spec.resources` map contains only those files. An unknown path returns an error.
+
+**Partial update:** Recognized `partial` values are `true`, `yes`, `1`, or empty (`?partial` or `?partial=true`). The Engine copies the current package, overwrites or adds the submitted files, then runs the usual render pipeline on the merged package. Omitted files stay in storage. Multiple `partial` values in one request are rejected.
 
 PackageRevisionResources storage is handled such that operations are primarily read-only for most operations. Updates are exclusively permitted on Draft packages. Content is retrieved on-demand, meaning it is not cached within the API server, and all storage-related operations are delegated to the Engine.
 

--- a/docs/content/en/docs/5_architecture_and_components/porch-apiserver/functionality.md
+++ b/docs/content/en/docs/5_architecture_and_components/porch-apiserver/functionality.md
@@ -65,7 +65,7 @@ Package contents are handled by storing resources as a map where each filename i
 
 Selectors are parsed from the resource name in the request (`<name>?file=Kptfile` or `<name>?partial=true`) because the Kubernetes aggregated GET/UPDATE handlers receive the path name, not a separate query object. Quote the name in the shell so `?` is not treated as a glob.
 
-**Get file filter:** Repeat `file` for each path (`?file=Kptfile&file=README.md`). The response `spec.resources` map contains only those files. An unknown path returns an error.
+**Get file filter:** Repeat `file` for each path (`?file=Kptfile&file=README.md`). The response `spec.resources` map contains only those files that exist in the package. Unknown paths are omitted; if none of the requested files exist, `spec.resources` is empty.
 
 **Partial update:** Recognized `partial` values are `true`, `yes`, `1`, or empty (`?partial` or `?partial=true`). The Engine copies the current package, overwrites or adds the submitted files, then runs the usual render pipeline on the merged package. Omitted files stay in storage. Multiple `partial` values in one request are rejected.
 

--- a/docs/content/en/docs/7_cli_api/_index.md
+++ b/docs/content/en/docs/7_cli_api/_index.md
@@ -70,7 +70,7 @@ The following lists provide a summary of the resources documented in the generat
 **porch.kpt.dev/v1alpha1:**
 
 - **PackageRevision** - Represents a specific revision of a package with metadata and lifecycle state
-- **PackageRevisionResources** - Contains a list of the files in a package revision, there is one PackageRevisionResources resource for each PackageRevision resource
+- **PackageRevisionResources** - Contains a list of the files in a package revision, there is one PackageRevisionResources resource for each PackageRevision resource. GET may include `?file=<path>` (repeatable) to return only those files. UPDATE may include `?partial=true` to merge submitted files instead of replacing the package. See [Reading Selected Package Files]({{% relref "/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md#reading-selected-package-files" %}}) and [Partial Package Content Updates]({{% relref "/docs/4_tutorials_and_how-tos/working_with_package_revisions/inspecting-packages.md#partial-package-content-updates" %}}).
 - **PorchPackage** - Represents a package in a repository, with one or more PackageRevision resources in each package
 
 **config.porch.kpt.dev/v1alpha1:**

--- a/docs/content/en/docs/7_cli_api/api-ref.md
+++ b/docs/content/en/docs/7_cli_api/api-ref.md
@@ -281,7 +281,9 @@ _Appears in:_
 
 #### PackageRevisionResources
 
-PackageRevisionResources
+PackageRevisionResources contains the file contents of a PackageRevision (filename → YAML).
+GET may append `?file=<path>` to the resource name (repeatable) to return only those files.
+UPDATE may append `?partial=true` to merge submitted files into the existing package instead of replacing it.
 
 
 

--- a/pkg/cache/dbcache/dbpackagerevision.go
+++ b/pkg/cache/dbcache/dbpackagerevision.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/kptdev/porch/pkg/util"
 	pctx "github.com/kptdev/porch/pkg/util/context"
+	"github.com/kptdev/porch/pkg/util/selector"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -158,7 +159,7 @@ func (pr *dbPackageRevision) savePackageRevision(ctx context.Context, saveResour
 		pr.updatedBy = getCurrentUser()
 	}
 
-	_, err := pkgRevReadFromDB(ctx, pr.Key(), false)
+	_, err := pkgRevReadFromDB(ctx, pr.Key(), false, selector.AllFiles)
 	if err == nil {
 		updErr := pkgRevUpdateDB(ctx, pr, saveResources)
 		if updErr == nil && saveResources {
@@ -183,7 +184,7 @@ func (pr *dbPackageRevision) UpdatePackageRevision(ctx context.Context) error {
 	_, span := tracer.Start(ctx, "dbPackageRevision::UpdatePackageRevision", trace.WithAttributes())
 	defer span.End()
 
-	if readPr, err := pkgRevReadFromDB(ctx, pr.Key(), true); err == nil {
+	if readPr, err := pkgRevReadFromDB(ctx, pr.Key(), true, selector.AllFiles); err == nil {
 		pr.copyToThis(readPr)
 		return nil
 	} else {
@@ -318,18 +319,8 @@ func (pr *dbPackageRevision) GetPackageRevision(ctx context.Context) (*porchapi.
 	}, nil
 }
 
-func (pr *dbPackageRevision) GetResources(ctx context.Context) (*porchapi.PackageRevisionResources, error) {
-	_, span := tracer.Start(ctx, "dbPackageRevision::GetResources", trace.WithAttributes())
-	defer span.End()
-
-	resources, err := pkgRevResourcesReadFromDB(ctx, pr.pkgRevKey)
-	if err != nil {
-		klog.V(5).Infof("pkgRevScanRowsFromDB: reading package revision %+v resources returned err: %q", pr.Key(), err)
-		return nil, err
-	}
-
-	klog.V(5).Infof("pkgRevScanRowsFromDB: reading package revision resources succeeded %+v", pr.Key())
-
+func (pr *dbPackageRevision) makePackageRevisionResources(resources map[string]string) *porchapi.PackageRevisionResources {
+	key := pr.Key()
 	return &porchapi.PackageRevisionResources{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevisionResources",
@@ -345,13 +336,43 @@ func (pr *dbPackageRevision) GetResources(ctx context.Context) (*porchapi.Packag
 			},
 		},
 		Spec: porchapi.PackageRevisionResourcesSpec{
-			PackageName:    pr.Key().PKey().Package,
-			WorkspaceName:  pr.Key().WorkspaceName,
-			Revision:       pr.Key().Revision,
-			RepositoryName: pr.Key().RKey().Name,
+			PackageName:    key.PKey().Package,
+			WorkspaceName:  key.WorkspaceName,
+			Revision:       key.Revision,
+			RepositoryName: key.RKey().Name,
 			Resources:      resources,
 		},
-	}, nil
+	}
+}
+
+func (pr *dbPackageRevision) GetResources(ctx context.Context) (*porchapi.PackageRevisionResources, error) {
+	ctx, span := tracer.Start(ctx, "dbPackageRevision::GetResources", trace.WithAttributes())
+	defer span.End()
+
+	resources, err := pkgRevResourcesReadFromDB(ctx, pr.pkgRevKey, selector.AllFiles)
+	if err != nil {
+		klog.V(5).Infof("pkgRevScanRowsFromDB: reading package revision %+v resources returned err: %q", pr.Key(), err)
+		return nil, err
+	}
+
+	klog.V(5).Infof("pkgRevScanRowsFromDB: reading package revision resources succeeded %+v", pr.Key())
+
+	return pr.makePackageRevisionResources(resources), nil
+}
+
+func (pr *dbPackageRevision) GetFilteredResources(ctx context.Context, selector selector.PRRGet) (*porchapi.PackageRevisionResources, error) {
+	ctx, span := tracer.Start(ctx, "dbPackageRevision::GetFilteredResources", trace.WithAttributes())
+	defer span.End()
+
+	resources, err := pkgRevResourcesReadFromDB(ctx, pr.pkgRevKey, selector)
+	if err != nil {
+		klog.V(5).Infof("pkgRevScanRowsFromDB: reading package revision %+v resources returned err: %q", pr.Key(), err)
+		return nil, err
+	}
+
+	klog.V(5).Infof("pkgRevScanRowsFromDB: reading package revision resources succeeded %+v", pr.Key())
+
+	return pr.makePackageRevisionResources(resources), nil
 }
 
 func (pr *dbPackageRevision) GetUpstreamLock(ctx context.Context) (kptfile.Upstream, kptfile.Locator, error) {
@@ -580,7 +601,7 @@ func (pr *dbPackageRevision) publishPlaceholderPRForPR(ctx context.Context) erro
 
 	prWithResources := pr
 	if len(prWithResources.resources) == 0 {
-		if readPR, err := pkgRevReadFromDB(ctx, pr.Key(), true); err == nil {
+		if readPR, err := pkgRevReadFromDB(ctx, pr.Key(), true, selector.AllFiles); err == nil {
 			prWithResources = readPR
 		} else {
 			return pkgerrors.Wrapf(err, "dbPackageRevision:publishPlaceholderPRForPR: could not read resources for package revision %+v from DB", pr.Key())

--- a/pkg/cache/dbcache/dbpackagerevision_test.go
+++ b/pkg/cache/dbcache/dbpackagerevision_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The kpt Authors
+// Copyright 2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -277,6 +277,66 @@ upstreamLock:
 
 	err = testRepo.Close(ctx)
 	t.Require().NoError(err)
+}
+
+func (t *DbTestSuite) TestDBPackageRevisionGetFilteredResourcesReturnsAllFiles() {
+	dbPR := t.createResourcesFixture("gfr-all-ns", "gfr-all-repo", "gfr-all-package", "gfr-all-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+
+	got, err := dbPR.GetFilteredResources(t.Context(), selector.AllFiles)
+
+	t.Require().NoError(err)
+	t.Require().NotNil(got)
+	t.Equal(map[string]string{helloResourceFile: helloResourceContent, goodbyeResourceFile: goodbyeResourceContent}, got.Spec.Resources)
+	t.assertPackageRevisionResourcesIdentity(got, dbPR)
+}
+
+func (t *DbTestSuite) TestDBPackageRevisionGetFilteredResourcesReturnsMatchingFiles() {
+	// given
+	dbPR := t.createResourcesFixture("gfr-one-ns", "gfr-one-repo", "gfr-one-package", "gfr-one-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+
+	// when
+	got, err := dbPR.GetFilteredResources(t.Context(), selector.PRRGet{FilePaths: []string{helloResourceFile}})
+
+	// then
+	t.Require().NoError(err)
+	t.Require().NotNil(got)
+	t.Equal(map[string]string{helloResourceFile: helloResourceContent}, got.Spec.Resources)
+	t.assertPackageRevisionResourcesIdentity(got, dbPR)
+}
+
+func (t *DbTestSuite) TestDBPackageRevisionGetFilteredResourcesOmitsUnknownFiles() {
+	// given
+	dbPR := t.createResourcesFixture("gfr-miss-ns", "gfr-miss-repo", "gfr-miss-package", "gfr-miss-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+
+	// when
+	got, err := dbPR.GetFilteredResources(t.Context(), selector.PRRGet{FilePaths: []string{missingResourceFile}})
+
+	// then
+	t.Require().NoError(err)
+	t.Require().NotNil(got)
+	t.Empty(got.Spec.Resources)
+}
+
+func (t *DbTestSuite) TestDBPackageRevisionGetFilteredResourcesReturnsErrorWhenDBReadFails() {
+	// given
+	dbPR := t.createResourcesFixture("gfr-err-ns", "gfr-err-repo", "gfr-err-package", "gfr-err-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+	origDB := GetDB().db
+	GetDB().db = &failingScanTwoTextColumnsSQL{
+		dbSQLInterface: origDB,
+		err:            errors.New("native scan failed"),
+	}
+	defer func() { GetDB().db = origDB }()
+
+	// when
+	got, err := dbPR.GetFilteredResources(t.Context(), selector.AllFiles)
+
+	// then
+	t.Require().Nil(got)
+	t.Require().ErrorContains(err, "native scan failed")
 }
 
 func (t *DbTestSuite) TestDBPackageRevisionDeleteWithNotFoundError() {
@@ -834,4 +894,23 @@ func (t *DbTestSuite) TestDBPackageRevisionPublishWithPushDraftsToGit() {
 	// everything this test created. Close only removes cached packages, not external ones.
 	extRepo.EXPECT().Close(mock.Anything).Return(nil).Once()
 	t.Require().NoError(testRepo.Close(ctx))
+}
+
+const (
+	helloResourceFile      = "Hello.txt"
+	helloResourceContent   = "Hello"
+	goodbyeResourceFile    = "Goodbye.txt"
+	goodbyeResourceContent = "Goodbye"
+	missingResourceFile    = "missing.yaml"
+)
+
+func (t *DbTestSuite) assertPackageRevisionResourcesIdentity(got *porchapi.PackageRevisionResources, pr dbPackageRevision) {
+	t.T().Helper()
+	key := pr.Key()
+	t.Equal(pr.KubeObjectName(), got.Name)
+	t.Equal(key.RKey().Namespace, got.Namespace)
+	t.Equal(key.PKey().Package, got.Spec.PackageName)
+	t.Equal(key.WorkspaceName, got.Spec.WorkspaceName)
+	t.Equal(key.Revision, got.Spec.Revision)
+	t.Equal(key.RKey().Name, got.Spec.RepositoryName)
 }

--- a/pkg/cache/dbcache/dbpackagerevision_test.go
+++ b/pkg/cache/dbcache/dbpackagerevision_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kptdev/porch/pkg/externalrepo/fake"
 	externalrepotypes "github.com/kptdev/porch/pkg/externalrepo/types"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	mockcachetypes "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/cache/types"
 	mockrepo "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/repository"
 	"github.com/stretchr/testify/mock"
@@ -172,7 +173,7 @@ info:
 		Revision:      -1,
 		WorkspaceName: branch,
 	}
-	mainFromDB, err := pkgRevReadFromDB(ctx, mainKey, false)
+	mainFromDB, err := pkgRevReadFromDB(ctx, mainKey, false, selector.AllFiles)
 	t.Require().NoError(err)
 	t.Require().NotNil(mainFromDB)
 
@@ -251,7 +252,7 @@ upstreamLock:
     ref: drafts/basens-edit/update-1
     commit: 960e1b80b5245874e46ba2b3090b27deaa61eb9a`
 
-	newDBPR2, err := pkgRevReadFromDB(ctx, dbPR.Key(), true)
+	newDBPR2, err := pkgRevReadFromDB(ctx, dbPR.Key(), true, selector.AllFiles)
 	t.Require().NoError(err)
 
 	err = newDBPR2.UpdateResources(ctx, prResources, &porchapi.Task{})

--- a/pkg/cache/dbcache/dbpackagerevisionresourcessql.go
+++ b/pkg/cache/dbcache/dbpackagerevisionresourcessql.go
@@ -17,10 +17,12 @@ package dbcache
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/kptdev/porch/internal/telemetry"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
 )
@@ -52,18 +54,36 @@ func pkgRevResourceReadFromDB(ctx context.Context, prk repository.PackageRevisio
 	return resKey, resVal, err
 }
 
-func pkgRevResourcesReadFromDB(ctx context.Context, prk repository.PackageRevisionKey) (map[string]string, error) {
+func pkgRevResourcesReadFromDB(ctx context.Context, prk repository.PackageRevisionKey, selector selector.PRRGet) (map[string]string, error) {
 	_, span := tracer.Start(ctx, "dbpackagerevisionresourcessql::pkgRevResourcesReadFromDB", trace.WithAttributes())
 	defer span.End()
 
 	klog.V(5).Infof("pkgRevResourcesReadFromDB: reading package revision resource %+v", prk)
 
-	sqlStatement := `SELECT resource_key, resource_value FROM resources WHERE k8s_name_space=$1 AND k8s_name=$2`
+	var resources map[string]string
+	if selector.IsAllFiles() {
+		resources = make(map[string]string)
+	} else {
+		resources = make(map[string]string, len(selector.FilePaths))
+	}
 
-	resources := make(map[string]string)
+	query, args := pkgRevResourcesQuerySQL(prk, selector)
+	klog.V(6).Infof("pkgRevResourcesReadFromDB: running query %q on package revision %+v", query, prk)
 
-	klog.V(6).Infof("pkgRevResourcesReadFromDB: running query %q on package revision %+v", sqlStatement, prk)
-	rows, err := GetDB().db.Query(ctx, sqlStatement, prk.K8SNS(), prk.K8SName())
+	err := GetDB().db.ScanTwoTextColumns(ctx, query, args, func(resKey, resVal string) error {
+		resources[resKey] = resVal
+		return nil
+	})
+	if err == nil {
+		klog.V(5).Infof("pkgRevResourcesReadFromDB: query succeeded for %q", prk)
+		return resources, nil
+	}
+	if !errors.Is(err, ErrPgxQueryUnsupported) {
+		klog.Warningf("pkgRevResourcesReadFromDB: query failed for %+v: %q", prk, err)
+		return nil, err
+	}
+
+	rows, err := pkgRevResourcesDbQuery(ctx, prk, selector)
 	if err != nil {
 		klog.Warningf("pkgRevResourcesReadFromDB: query failed for %+v: %q", prk, err)
 		return nil, err
@@ -82,6 +102,25 @@ func pkgRevResourcesReadFromDB(ctx context.Context, prk repository.PackageRevisi
 	}
 
 	return resources, nil
+}
+
+func pkgRevResourcesQuerySQL(prk repository.PackageRevisionKey, selector selector.PRRGet) (string, []any) {
+	if selector.IsAllFiles() {
+		return `SELECT resource_key, resource_value FROM resources WHERE k8s_name_space=$1 AND k8s_name=$2`,
+			[]any{prk.K8SNS(), prk.K8SName()}
+	}
+	return `SELECT resource_key, resource_value FROM resources WHERE k8s_name_space=$1 AND k8s_name=$2 AND resource_key=ANY($3)`,
+		[]any{prk.K8SNS(), prk.K8SName(), selector.FilePaths}
+}
+
+func pkgRevResourcesDbQuery(ctx context.Context, prk repository.PackageRevisionKey, selector selector.PRRGet) (*sql.Rows, error) {
+	sqlStatement, args := pkgRevResourcesQuerySQL(prk, selector)
+	if selector.IsAllFiles() {
+		klog.V(6).Infof("pkgRevResourcesReadFromDB: running query %q on package revision %+v", sqlStatement, prk)
+	} else {
+		klog.V(6).Infof("pkgRevResourcesReadFromDB: running query %q on package revision %+v filter the files %q", sqlStatement, prk, selector.FilePaths)
+	}
+	return GetDB().db.Query(ctx, sqlStatement, args...)
 }
 
 func pkgRevResourcesWriteToDB(ctx context.Context, pr *dbPackageRevision) error {

--- a/pkg/cache/dbcache/dbpackagerevisionresourcessql_test.go
+++ b/pkg/cache/dbcache/dbpackagerevisionresourcessql_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or granted to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbcache
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	cachetypes "github.com/kptdev/porch/pkg/cache/types"
+	"github.com/kptdev/porch/pkg/util/selector"
+	mockcachetypes "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/cache/types"
+	"github.com/stretchr/testify/mock"
+)
+
+func (t *DbTestSuite) TestPkgRevResourcesReadFromDBFallsBackToStdlibQuery() {
+	dbPR := t.createResourcesFixture("fallback-ns", "fallback-repo", "fallback-package", "fallback-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+	origDB := GetDB().db
+	GetDB().db = &forceStdlibResourceQuerySQL{dbSQLInterface: origDB}
+	defer func() { GetDB().db = origDB }()
+
+	resources, err := pkgRevResourcesReadFromDB(t.Context(), dbPR.Key(), selector.AllFiles)
+
+	t.Require().NoError(err)
+	t.Equal("Hello", resources["Hello.txt"])
+	t.Equal("Goodbye", resources["Goodbye.txt"])
+}
+
+func (t *DbTestSuite) TestPkgRevResourcesReadFromDBFallsBackToStdlibQueryWithFileFilter() {
+	dbPR := t.createResourcesFixture("filter-ns", "filter-repo", "filter-package", "filter-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+	origDB := GetDB().db
+	GetDB().db = &forceStdlibResourceQuerySQL{dbSQLInterface: origDB}
+	defer func() { GetDB().db = origDB }()
+
+	resources, err := pkgRevResourcesReadFromDB(t.Context(), dbPR.Key(), selector.PRRGet{FilePaths: []string{"Hello.txt"}})
+
+	t.Require().NoError(err)
+	t.Equal(map[string]string{"Hello.txt": "Hello"}, resources)
+}
+
+func (t *DbTestSuite) TestPkgRevResourcesReadFromDBReturnsQueryErrorOnFallback() {
+	dbPR := t.createResourcesFixture("queryerr-ns", "queryerr-repo", "queryerr-package", "queryerr-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+	origDB := GetDB().db
+	GetDB().db = &failingStdlibResourceQuerySQL{
+		dbSQLInterface: origDB,
+		queryErr:       fmt.Errorf("query failed"),
+	}
+	defer func() { GetDB().db = origDB }()
+
+	resources, err := pkgRevResourcesReadFromDB(t.Context(), dbPR.Key(), selector.AllFiles)
+
+	t.Require().Nil(resources)
+	t.Require().ErrorContains(err, "query failed")
+}
+
+func (t *DbTestSuite) TestPkgRevResourcesReadFromDBReturnsScanErrorOnFallback() {
+	dbPR := t.createResourcesFixture("scanerr-ns", "scanerr-repo", "scanerr-package", "scanerr-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+	origDB := GetDB().db
+	GetDB().db = &oneColumnResourceQuerySQL{dbSQLInterface: origDB}
+	defer func() { GetDB().db = origDB }()
+
+	resources, err := pkgRevResourcesReadFromDB(t.Context(), dbPR.Key(), selector.AllFiles)
+
+	t.Require().Nil(resources)
+	t.Require().Error(err)
+}
+
+func (t *DbTestSuite) TestPkgRevResourcesReadFromDBReturnsScanTwoTextColumnsError() {
+	dbPR := t.createResourcesFixture("scan2-ns", "scan2-repo", "scan2-package", "scan2-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+	origDB := GetDB().db
+	GetDB().db = &failingScanTwoTextColumnsSQL{
+		dbSQLInterface: origDB,
+		err:            errors.New("native scan failed"),
+	}
+	defer func() { GetDB().db = origDB }()
+
+	resources, err := pkgRevResourcesReadFromDB(t.Context(), dbPR.Key(), selector.AllFiles)
+
+	t.Require().Nil(resources)
+	t.Require().ErrorContains(err, "native scan failed")
+}
+
+func (t *DbTestSuite) TestPkgRevResourcesDbQueryReturnsAllFiles() {
+	dbPR := t.createResourcesFixture("dbquery-ns", "dbquery-repo", "dbquery-package", "dbquery-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+
+	rows, err := pkgRevResourcesDbQuery(t.Context(), dbPR.Key(), selector.AllFiles)
+
+	t.Require().NoError(err)
+	defer rows.Close()
+	t.Equal(map[string]string{"Hello.txt": "Hello", "Goodbye.txt": "Goodbye"}, scanResourceRows(t, rows))
+}
+
+func (t *DbTestSuite) TestPkgRevResourcesDbQueryReturnsFilteredFiles() {
+	dbPR := t.createResourcesFixture("dbqueryf-ns", "dbqueryf-repo", "dbqueryf-package", "dbqueryf-pr")
+	defer t.deleteTestRepo(dbPR.Key().RKey())
+
+	rows, err := pkgRevResourcesDbQuery(t.Context(), dbPR.Key(), selector.PRRGet{FilePaths: []string{"Goodbye.txt"}})
+
+	t.Require().NoError(err)
+	defer rows.Close()
+	t.Equal(map[string]string{"Goodbye.txt": "Goodbye"}, scanResourceRows(t, rows))
+}
+
+func (t *DbTestSuite) createResourcesFixture(namespace, repoName, packageName, workspaceName string) dbPackageRevision {
+	t.T().Helper()
+	mockCache := mockcachetypes.NewMockCache(t.T())
+	cachetypes.CacheInstance = mockCache
+	mockCache.EXPECT().GetRepository(mock.Anything).Return(&dbRepository{})
+
+	dbRepo := t.createTestRepo(namespace, repoName)
+	dbPkg := t.createTestPkg(dbRepo.Key(), packageName)
+	dbPkg.repo = dbRepo
+	dbPR := t.createTestPR(dbPkg.Key(), workspaceName)
+	dbPR.repo = dbRepo
+	return dbPR
+}
+
+func scanResourceRows(t *DbTestSuite, rows *sql.Rows) map[string]string {
+	t.T().Helper()
+	resources := map[string]string{}
+	for rows.Next() {
+		var resKey, resVal string
+		t.Require().NoError(rows.Scan(&resKey, &resVal))
+		resources[resKey] = resVal
+	}
+	t.Require().NoError(rows.Err())
+	return resources
+}
+
+type forceStdlibResourceQuerySQL struct {
+	dbSQLInterface
+}
+
+func (f *forceStdlibResourceQuerySQL) ScanTwoTextColumns(context.Context, string, []any, func(col1, col2 string) error) error {
+	return ErrPgxQueryUnsupported
+}
+
+type failingStdlibResourceQuerySQL struct {
+	dbSQLInterface
+	queryErr error
+}
+
+func (f *failingStdlibResourceQuerySQL) ScanTwoTextColumns(context.Context, string, []any, func(col1, col2 string) error) error {
+	return ErrPgxQueryUnsupported
+}
+
+func (f *failingStdlibResourceQuerySQL) Query(context.Context, string, ...any) (*sql.Rows, error) {
+	return nil, f.queryErr
+}
+
+type oneColumnResourceQuerySQL struct {
+	dbSQLInterface
+}
+
+func (f *oneColumnResourceQuerySQL) ScanTwoTextColumns(context.Context, string, []any, func(col1, col2 string) error) error {
+	return ErrPgxQueryUnsupported
+}
+
+func (f *oneColumnResourceQuerySQL) Query(ctx context.Context, _ string, _ ...any) (*sql.Rows, error) {
+	return f.dbSQLInterface.Query(ctx, `SELECT 'only-one-column'`)
+}
+
+type failingScanTwoTextColumnsSQL struct {
+	dbSQLInterface
+	err error
+}
+
+func (f *failingScanTwoTextColumnsSQL) ScanTwoTextColumns(context.Context, string, []any, func(col1, col2 string) error) error {
+	return f.err
+}

--- a/pkg/cache/dbcache/dbpackagerevisionsql.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql.go
@@ -23,11 +23,12 @@ import (
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	cachetypes "github.com/kptdev/porch/pkg/cache/types"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
 )
 
-func pkgRevReadFromDB(ctx context.Context, prk repository.PackageRevisionKey, readResources bool) (*dbPackageRevision, error) {
+func pkgRevReadFromDB(ctx context.Context, prk repository.PackageRevisionKey, readResources bool, selector selector.PRRGet) (*dbPackageRevision, error) {
 	_, span := tracer.Start(ctx, "dbpackagerevisionsql::pkgRevReadFromDB", trace.WithAttributes())
 	defer span.End()
 
@@ -91,7 +92,7 @@ func pkgRevReadFromDB(ctx context.Context, prk repository.PackageRevisionKey, re
 		return readPr, nil
 	}
 
-	resources, err := pkgRevResourcesReadFromDB(ctx, readPr.Key())
+	resources, err := pkgRevResourcesReadFromDB(ctx, readPr.Key(), selector)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/dbcache/dbpackagerevisionsql_test.go
+++ b/pkg/cache/dbcache/dbpackagerevisionsql_test.go
@@ -22,6 +22,7 @@ import (
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	cachetypes "github.com/kptdev/porch/pkg/cache/types"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	mockcachetypes "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/cache/types"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -158,7 +159,7 @@ func (t *DbTestSuite) TestPackageRevisionLatest() {
 	t.Require().NoError(err)
 	t.Equal(1, latestPR.pkgRevKey.Revision)
 
-	resources, err := pkgRevResourcesReadFromDB(t.Context(), latestPR.Key())
+	resources, err := pkgRevResourcesReadFromDB(t.Context(), latestPR.Key(), selector.AllFiles)
 	t.Require().NoError(err)
 
 	latestPR.resources = resources
@@ -394,7 +395,7 @@ func (t *DbTestSuite) TestPackageRevisionDBSchema() {
 	err = repoDeleteFromDB(t.Context(), dbRepo.Key())
 	t.Require().NoError(err)
 
-	_, err = pkgRevReadFromDB(t.Context(), dbPR.Key(), false)
+	_, err = pkgRevReadFromDB(t.Context(), dbPR.Key(), false, selector.AllFiles)
 	t.Require().NotNil(err)
 	t.Equal(sql.ErrNoRows, err)
 }
@@ -728,10 +729,10 @@ func (t *DbTestSuite) pkgRevDBWriteReadTest(dbRepo *dbRepository, dbPkg dbPackag
 	err = pkgRevWriteToDB(t.Context(), &dbPR)
 	t.Require().NoError(err)
 
-	readPR, err := pkgRevReadFromDB(t.Context(), dbPR.Key(), false)
+	readPR, err := pkgRevReadFromDB(t.Context(), dbPR.Key(), false, selector.AllFiles)
 	t.Require().NoError(err)
 
-	resources, err := pkgRevResourcesReadFromDB(t.Context(), readPR.Key())
+	resources, err := pkgRevResourcesReadFromDB(t.Context(), readPR.Key(), selector.AllFiles)
 	t.Require().NoError(err)
 
 	readPR.resources = resources
@@ -744,10 +745,10 @@ func (t *DbTestSuite) pkgRevDBWriteReadTest(dbRepo *dbRepository, dbPkg dbPackag
 	err = pkgRevUpdateDB(t.Context(), &dbPRUpdate, true)
 	t.Require().NoError(err)
 
-	readPR, err = pkgRevReadFromDB(t.Context(), dbPR.Key(), false)
+	readPR, err = pkgRevReadFromDB(t.Context(), dbPR.Key(), false, selector.AllFiles)
 	t.Require().NoError(err)
 
-	resources, err = pkgRevResourcesReadFromDB(t.Context(), readPR.Key())
+	resources, err = pkgRevResourcesReadFromDB(t.Context(), readPR.Key(), selector.AllFiles)
 	t.Require().NoError(err)
 
 	readPR.resources = resources
@@ -757,7 +758,7 @@ func (t *DbTestSuite) pkgRevDBWriteReadTest(dbRepo *dbRepository, dbPkg dbPackag
 	err = pkgRevDeleteFromDB(t.Context(), dbPR.Key())
 	t.Require().NoError(err)
 
-	_, err = pkgRevReadFromDB(t.Context(), dbPR.Key(), false)
+	_, err = pkgRevReadFromDB(t.Context(), dbPR.Key(), false, selector.AllFiles)
 	t.Require().NotNil(err)
 	t.Equal(sql.ErrNoRows, err)
 
@@ -812,7 +813,7 @@ func (t *DbTestSuite) assertPackageRevListsEqual(left []dbPackageRevision, right
 
 	leftMap := make(map[repository.PackageRevisionKey]*dbPackageRevision)
 	for _, leftPr := range left {
-		resources, err := pkgRevResourcesReadFromDB(t.Context(), leftPr.Key())
+		resources, err := pkgRevResourcesReadFromDB(t.Context(), leftPr.Key(), selector.AllFiles)
 		t.Require().NoError(err)
 
 		leftPr.resources = resources
@@ -823,7 +824,7 @@ func (t *DbTestSuite) assertPackageRevListsEqual(left []dbPackageRevision, right
 	for _, rightPr := range right {
 		rightMap[rightPr.Key()] = rightPr
 
-		resources, err := pkgRevResourcesReadFromDB(t.Context(), rightPr.Key())
+		resources, err := pkgRevResourcesReadFromDB(t.Context(), rightPr.Key(), selector.AllFiles)
 		t.Require().NoError(err)
 
 		rightPr.resources = resources

--- a/pkg/cache/dbcache/dbreposync_test.go
+++ b/pkg/cache/dbcache/dbreposync_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kptdev/porch/pkg/externalrepo/fake"
 	externalrepotypes "github.com/kptdev/porch/pkg/externalrepo/types"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	mockcachetypes "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/cache/types"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -588,7 +589,7 @@ func (t *DbTestSuite) TestCacheExternalPRs_SkipsBinaryFiles() {
 	t.Require().NoError(err, "sync should not fail due to binary file")
 
 	// Verify resources read directly from DB
-	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey)
+	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey, selector.AllFiles)
 	t.Require().NoError(err)
 
 	// Text files should exist
@@ -679,7 +680,7 @@ func (t *DbTestSuite) TestCacheExternalPRs_AllTextFiles() {
 	err = repoSync.cacheExternalPRs(ctx, extPRMap, inExternalOnly)
 	t.Require().NoError(err)
 
-	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey)
+	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey, selector.AllFiles)
 	t.Require().NoError(err)
 
 	// All 3 files should exist
@@ -769,7 +770,7 @@ func (t *DbTestSuite) TestCacheExternalPRs_AllBinaryFiles() {
 	err = repoSync.cacheExternalPRs(ctx, extPRMap, inExternalOnly)
 	t.Require().NoError(err, "all binary files should not cause error")
 
-	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey)
+	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey, selector.AllFiles)
 	t.Require().NoError(err)
 
 	// All should be skipped
@@ -849,7 +850,7 @@ func (t *DbTestSuite) TestCacheExternalPRs_EmptyResources() {
 	err = repoSync.cacheExternalPRs(ctx, extPRMap, inExternalOnly)
 	t.Require().NoError(err, "empty resources should not cause error")
 
-	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey)
+	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey, selector.AllFiles)
 	t.Require().NoError(err)
 	t.Empty(cachedResources, "empty resources should return empty map")
 }
@@ -932,7 +933,7 @@ func (t *DbTestSuite) TestCacheExternalPRs_SkipsNulByteContent() {
 	err = repoSync.cacheExternalPRs(ctx, extPRMap, inExternalOnly)
 	t.Require().NoError(err, "sync should not fail due to NUL byte content")
 
-	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey)
+	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey, selector.AllFiles)
 	t.Require().NoError(err)
 
 	// Text files should be cached
@@ -1024,7 +1025,7 @@ func (t *DbTestSuite) TestCacheExternalPRs_SkipsInvalidFilePath() {
 	err = repoSync.cacheExternalPRs(ctx, extPRMap, inExternalOnly)
 	t.Require().NoError(err, "sync should not fail due to invalid filepath")
 
-	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey)
+	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey, selector.AllFiles)
 	t.Require().NoError(err)
 
 	// Valid files should be cached
@@ -1107,7 +1108,7 @@ func (t *DbTestSuite) TestCacheExternalPRs_NilResources() {
 	err = repoSync.cacheExternalPRs(ctx, extPRMap, inExternalOnly)
 	t.Require().NoError(err, "nil resources should not cause panic or error")
 
-	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey)
+	cachedResources, err := pkgRevResourcesReadFromDB(ctx, prKey, selector.AllFiles)
 	t.Require().NoError(err)
 	t.Empty(cachedResources, "nil resources should result in empty cached resources")
 }

--- a/pkg/cache/dbcache/dbsql.go
+++ b/pkg/cache/dbcache/dbsql.go
@@ -17,7 +17,15 @@ package dbcache
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+
+	"github.com/jackc/pgx/v5/stdlib"
+)
+
+var (
+	ErrCopyUnsupported     = errors.New("bulk copy not supported by this driver")
+	ErrPgxQueryUnsupported = errors.New("native pgx query not supported by this driver")
 )
 
 type dbSQLInterface interface {
@@ -26,6 +34,7 @@ type dbSQLInterface interface {
 	Exec(ctx context.Context, query string, args ...any) (sql.Result, error)
 	Query(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	QueryRow(ctx context.Context, query string, args ...any) *sql.Row
+	ScanTwoTextColumns(ctx context.Context, query string, args []any, scan func(col1, col2 string) error) error
 }
 
 var _ dbSQLInterface = &dbSQL{}
@@ -72,4 +81,41 @@ func (ds *dbSQL) QueryRow(ctx context.Context, query string, args ...any) *sql.R
 	} else {
 		return nil
 	}
+}
+
+func (ds *dbSQL) ScanTwoTextColumns(ctx context.Context, query string, args []any, scan func(col1, col2 string) error) error {
+	if ds.db == nil {
+		return fmt.Errorf("cannot query database, database is not initialized")
+	}
+
+	conn, err := ds.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	return conn.Raw(func(driverConn any) error {
+		stdlibConn, ok := driverConn.(*stdlib.Conn)
+		if !ok {
+			return ErrPgxQueryUnsupported
+		}
+
+		rows, err := stdlibConn.Conn().Query(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var col1, col2 string
+			if err := rows.Scan(&col1, &col2); err != nil {
+				return err
+			}
+			if err := scan(col1, col2); err != nil {
+				return err
+			}
+		}
+
+		return rows.Err()
+	})
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kptdev/porch/pkg/task"
 	"github.com/kptdev/porch/pkg/util"
 	pctx "github.com/kptdev/porch/pkg/util/context"
+	"github.com/kptdev/porch/pkg/util/selector"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -46,7 +47,7 @@ type CaDEngine interface {
 	// ObjectCache() is a cache of all our objects.
 	ObjectCache() WatcherManager
 
-	UpdatePackageResources(ctx context.Context, repositoryObj *configapi.Repository, oldPackage repository.PackageRevision, old, new *porchapi.PackageRevisionResources) (repository.PackageRevision, *porchapi.RenderStatus, error)
+	UpdatePackageResources(ctx context.Context, repositoryObj *configapi.Repository, oldPackage repository.PackageRevision, old, new *porchapi.PackageRevisionResources, resourceSelector selector.PRRUpdate) (repository.PackageRevision, *porchapi.RenderStatus, error)
 	UpdatePackageResourcesWithoutRender(ctx context.Context, repositoryObj *configapi.Repository, oldPackage repository.PackageRevision, old, new *porchapi.PackageRevisionResources) (repository.PackageRevision, error)
 
 	ListPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error)
@@ -470,7 +471,7 @@ func (cad *cadEngine) ListPackages(ctx context.Context, repositorySpec *configap
 	return packages, nil
 }
 
-func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj *configapi.Repository, pr2Update repository.PackageRevision, oldRes, newRes *porchapi.PackageRevisionResources) (repository.PackageRevision, *porchapi.RenderStatus, error) {
+func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj *configapi.Repository, pr2Update repository.PackageRevision, oldRes, newRes *porchapi.PackageRevisionResources, resourceSelector selector.PRRUpdate) (repository.PackageRevision, *porchapi.RenderStatus, error) {
 	ctx, span := tracer.Start(ctx, "cadEngine::UpdatePackageResources", trace.WithAttributes())
 	defer span.End()
 
@@ -485,15 +486,6 @@ func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj 
 		return nil, nil, err
 	}
 
-	newRV := newRes.GetResourceVersion()
-	if len(newRV) == 0 {
-		return nil, nil, fmt.Errorf("resourceVersion must be specified for an update")
-	}
-
-	if newRV != oldRes.GetResourceVersion() {
-		return nil, nil, apierrors.NewConflict(porchapi.Resource("packagerevisionresources"), oldRes.GetName(), errors.New(OptimisticLockErrorMsg))
-	}
-
 	// Validate package lifecycle. Can only update a draft.
 	switch lifecycle := rev.Spec.Lifecycle; lifecycle {
 	default:
@@ -505,6 +497,15 @@ func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj 
 		return nil, nil, fmt.Errorf("cannot update a package revision with lifecycle value %q; package must be Draft", lifecycle)
 	}
 
+	newRV := newRes.GetResourceVersion()
+	if len(newRV) == 0 {
+		return nil, nil, fmt.Errorf("resourceVersion must be specified for an update")
+	}
+
+	if newRV != oldRes.GetResourceVersion() {
+		return nil, nil, apierrors.NewConflict(porchapi.Resource("packagerevisionresources"), oldRes.GetName(), errors.New(OptimisticLockErrorMsg))
+	}
+
 	repo, err := cad.cache.OpenRepository(ctx, repositoryObj)
 	if err != nil {
 		return nil, nil, err
@@ -513,6 +514,9 @@ func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	prr := cad.makePackageRevisionResources(oldRes.Spec.Resources, newRes.Spec.Resources, resourceSelector)
+	newRes.Spec.Resources = prr.Spec.Resources
 
 	renderStatus, renderErr := cad.taskHandler.DoPRResourceMutations(ctx, pr2Update, draft, oldRes, newRes)
 
@@ -612,4 +616,27 @@ func handleMutationError(renderErr error, rev *porchapi.PackageRevision) (reposi
 	}
 
 	return nil, nil
+}
+
+func (cad *cadEngine) makePackageRevisionResources(oldResources, newResources map[string]string, resourceSelector selector.PRRUpdate) *porchapi.PackageRevisionResources {
+	if resourceSelector.Partial {
+		clonedOldResources := map[string]string{}
+		for k, v := range oldResources {
+			clonedOldResources[k] = v
+		}
+		for k, v := range newResources {
+			clonedOldResources[k] = v
+		}
+		return &porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: clonedOldResources,
+			},
+		}
+	}
+
+	return &porchapi.PackageRevisionResources{
+		Spec: porchapi.PackageRevisionResourcesSpec{
+			Resources: newResources,
+		},
+	}
 }

--- a/pkg/engine/engine_packages_test.go
+++ b/pkg/engine/engine_packages_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	configapi "github.com/kptdev/porch/api/porchconfig/v1alpha1"
+	"github.com/kptdev/porch/pkg/externalrepo/fake"
+	"github.com/kptdev/porch/pkg/repository"
+	mockrepo "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/repository"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestListPackagesReturnsPackagesFromRepository(t *testing.T) {
+	f := newTestFixture(t)
+	expected := []repository.Package{
+		&fake.FakePackage{PkgKey: repository.PackageKey{Package: "pkg-a"}},
+		&fake.FakePackage{PkgKey: repository.PackageKey{Package: "pkg-b"}},
+	}
+	f.mockRepo.On("ListPackages", mock.Anything, mock.Anything).Return(expected, nil)
+
+	got, err := f.engine.ListPackages(context.Background(), f.repositoryObj, repository.ListPackageFilter{})
+
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+	f.mockRepo.AssertExpectations(t)
+	f.mockCache.AssertExpectations(t)
+}
+
+func TestListPackagesReturnsErrorWhenOpeningRepositoryFails(t *testing.T) {
+	mockCache := &mockCache{}
+	repositoryObj := &configapi.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "default"},
+	}
+	mockCache.On("OpenRepository", mock.Anything, repositoryObj).
+		Return((*mockrepo.MockRepository)(nil), fmt.Errorf("repo unavailable"))
+	engine := &cadEngine{cache: mockCache}
+
+	got, err := engine.ListPackages(context.Background(), repositoryObj, repository.ListPackageFilter{})
+
+	require.Nil(t, got)
+	require.ErrorContains(t, err, "repo unavailable")
+}
+
+func TestListPackagesReturnsErrorWhenListingPackagesFails(t *testing.T) {
+	f := newTestFixture(t)
+	f.mockRepo.On("ListPackages", mock.Anything, mock.Anything).
+		Return([]repository.Package(nil), fmt.Errorf("list failed"))
+
+	got, err := f.engine.ListPackages(context.Background(), f.repositoryObj, repository.ListPackageFilter{})
+
+	require.Nil(t, got)
+	require.ErrorContains(t, err, "list failed")
+}
+
+func TestDeletePackageRevisionDeletesFromRepository(t *testing.T) {
+	f := newTestFixture(t)
+	pkgRev := setupMockPackageRevision(t)
+	f.mockRepo.On("DeletePackageRevision", mock.Anything, pkgRev).Return(nil)
+
+	err := f.engine.DeletePackageRevision(context.Background(), f.repositoryObj, pkgRev)
+
+	require.NoError(t, err)
+	f.mockRepo.AssertExpectations(t)
+	f.mockCache.AssertExpectations(t)
+}
+
+func TestDeletePackageRevisionReturnsErrorWhenOpeningRepositoryFails(t *testing.T) {
+	mockCache := &mockCache{}
+	repositoryObj := &configapi.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "default"},
+	}
+	mockCache.On("OpenRepository", mock.Anything, repositoryObj).
+		Return((*mockrepo.MockRepository)(nil), fmt.Errorf("repo unavailable"))
+	engine := &cadEngine{cache: mockCache}
+
+	err := engine.DeletePackageRevision(context.Background(), repositoryObj, setupMockPackageRevision(t))
+
+	require.ErrorContains(t, err, "repo unavailable")
+}
+
+func TestDeletePackageRevisionReturnsErrorWhenRepositoryDeleteFails(t *testing.T) {
+	f := newTestFixture(t)
+	pkgRev := setupMockPackageRevision(t)
+	f.mockRepo.On("DeletePackageRevision", mock.Anything, pkgRev).Return(fmt.Errorf("delete failed"))
+
+	err := f.engine.DeletePackageRevision(context.Background(), f.repositoryObj, pkgRev)
+
+	require.ErrorContains(t, err, "delete failed")
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -22,6 +22,7 @@ import (
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	"github.com/kptdev/porch/pkg/externalrepo/fake"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -1285,6 +1286,7 @@ func TestUpdatePackageResourcesRenderFailure(t *testing.T) {
 		expectError           bool
 		expectErrContains     []string
 		expectClose           bool
+		resourceSelector      selector.PRRUpdate
 	}{
 		{
 			name:                  "success - no render error",
@@ -1292,6 +1294,7 @@ func TestUpdatePackageResourcesRenderFailure(t *testing.T) {
 			expectPackageReturned: true,
 			expectError:           false,
 			expectClose:           true,
+			resourceSelector:      selector.Complete,
 		},
 		{
 			name:                  "push on render failure - annotation enabled",
@@ -1300,6 +1303,7 @@ func TestUpdatePackageResourcesRenderFailure(t *testing.T) {
 			expectPackageReturned: false,
 			expectError:           true,
 			expectClose:           true,
+			resourceSelector:      selector.Complete,
 		},
 		{
 			name:                  "no push on render failure - no annotation",
@@ -1307,6 +1311,7 @@ func TestUpdatePackageResourcesRenderFailure(t *testing.T) {
 			expectPackageReturned: false,
 			expectError:           true,
 			expectClose:           false,
+			resourceSelector:      selector.Complete,
 		},
 		{
 			name:                  "push on render failure - close draft also fails",
@@ -1317,6 +1322,7 @@ func TestUpdatePackageResourcesRenderFailure(t *testing.T) {
 			expectError:           true,
 			expectErrContains:     []string{"git push failed", "render failed"},
 			expectClose:           true,
+			resourceSelector:      selector.Complete,
 		},
 		{
 			name:                  "persistence failure - no push even with annotation",
@@ -1326,6 +1332,7 @@ func TestUpdatePackageResourcesRenderFailure(t *testing.T) {
 			expectError:           true,
 			expectErrContains:     []string{"draft update failed", "render failed"},
 			expectClose:           false,
+			resourceSelector:      selector.Complete,
 		},
 		{
 			name:                  "generic persistence error - no push even with annotation",
@@ -1335,6 +1342,7 @@ func TestUpdatePackageResourcesRenderFailure(t *testing.T) {
 			expectError:           true,
 			expectErrContains:     []string{"draft update failed"},
 			expectClose:           false,
+			resourceSelector:      selector.Complete,
 		},
 	}
 
@@ -1395,7 +1403,7 @@ func TestUpdatePackageResourcesRenderFailure(t *testing.T) {
 				taskHandler: mockTaskHandler,
 			}
 
-			pkgRev, renderStatus, err := engine.UpdatePackageResources(context.Background(), repositoryObj, mockPkgRev, oldRes, newRes)
+			pkgRev, renderStatus, err := engine.UpdatePackageResources(context.Background(), repositoryObj, mockPkgRev, oldRes, newRes, tt.resourceSelector)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/externalrepo/fake/packagerevision.go
+++ b/pkg/externalrepo/fake/packagerevision.go
@@ -22,6 +22,7 @@ import (
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/kptdev/porch/pkg/util"
+	"github.com/kptdev/porch/pkg/util/selector"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -86,6 +87,11 @@ func (fpr *FakePackageRevision) GetPackageRevision(context.Context) (*porchapi.P
 
 func (fpr *FakePackageRevision) GetResources(context.Context) (*porchapi.PackageRevisionResources, error) {
 	fpr.Ops = append(fpr.Ops, "GetResources")
+	return fpr.Resources, fpr.Err
+}
+
+func (fpr *FakePackageRevision) GetFilteredResources(context.Context, selector.PRRGet) (*porchapi.PackageRevisionResources, error) {
+	fpr.Ops = append(fpr.Ops, "GetFilteredResources")
 	return fpr.Resources, fpr.Err
 }
 

--- a/pkg/externalrepo/git/git.go
+++ b/pkg/externalrepo/git/git.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/kptdev/porch/pkg/util"
 	pctx "github.com/kptdev/porch/pkg/util/context"
+	"github.com/kptdev/porch/pkg/util/selector"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -1589,23 +1590,36 @@ func visitCommitsCollectErrors(iterator object.CommitIter, callback commitCallba
 	return ec.Join()
 }
 
-func (r *gitRepository) getResource(hash plumbing.Hash, filePath string) (string, error) {
-	var content string
+func (r *gitRepository) getFilteredResources(hash plumbing.Hash, selector selector.PRRGet) (map[string]string, error) {
+	if selector.IsAllFiles() {
+		return r.getResources(hash)
+	}
+
+	resources := map[string]string{}
 	err := r.sharedDir.withLock(func(repo *git.Repository) error {
 		tree, err := repo.TreeObject(hash)
 		if err != nil {
 			return err
 		}
 
-		file, err := tree.File(filePath)
-		if err != nil {
-			return err
+		for _, filePath := range selector.FilePaths {
+			file, errFile := tree.File(filePath)
+			if errFile != nil {
+				return errFile
+			}
+			content, errContents := file.Contents()
+			if errContents != nil {
+				return pkgerrors.Wrapf(errContents, "failed to read package file contents of %q", file.Name)
+			}
+			resources[filePath] = content
 		}
-
-		content, err = file.Contents()
-		return err
+		return nil
 	})
-	return content, err
+
+	if err != nil {
+		return nil, err
+	}
+	return resources, nil
 }
 
 func (r *gitRepository) getResources(hash plumbing.Hash) (map[string]string, error) {

--- a/pkg/externalrepo/git/package.go
+++ b/pkg/externalrepo/git/package.go
@@ -27,6 +27,7 @@ import (
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/kptdev/porch/pkg/util"
+	"github.com/kptdev/porch/pkg/util/selector"
 	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -135,7 +136,26 @@ func (p *gitPackageRevision) GetResources(context.Context) (*porchapi.PackageRev
 	}
 
 	p.mutex.Lock()
-	prRes := &porchapi.PackageRevisionResources{
+	prRes := p.makePackageRevisionResources(resources)
+	p.mutex.Unlock()
+	return prRes, nil
+}
+
+func (p *gitPackageRevision) GetFilteredResources(ctx context.Context, selector selector.PRRGet) (*porchapi.PackageRevisionResources, error) {
+	resources, err := p.repo.getFilteredResources(p.tree, selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load package resources: %w", err)
+	}
+
+	p.mutex.Lock()
+	prRes := p.makePackageRevisionResources(resources)
+	p.mutex.Unlock()
+
+	return prRes, nil
+}
+
+func (p *gitPackageRevision) makePackageRevisionResources(resources map[string]string) *porchapi.PackageRevisionResources {
+	return &porchapi.PackageRevisionResources{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevisionResources",
 			APIVersion: porchapi.SchemeGroupVersion.Identifier(),
@@ -159,8 +179,6 @@ func (p *gitPackageRevision) GetResources(context.Context) (*porchapi.PackageRev
 			Resources: resources,
 		},
 	}
-	p.mutex.Unlock()
-	return prRes, nil
 }
 
 // Creates a gitPackageRevision reference that is acting as the main branch package revision.
@@ -188,11 +206,11 @@ func (p *gitPackageRevision) ToMainPackageRevision(context.Context) repository.P
 }
 
 func (p *gitPackageRevision) GetKptfile(context.Context) (kptfilev1.KptFile, error) {
-	kfString, err := p.repo.getResource(p.tree, kptfilev1.KptFileName)
+	kfResourceMap, err := p.repo.getFilteredResources(p.tree, selector.KptFile)
 	if err != nil {
 		return kptfilev1.KptFile{}, pkgerrors.Wrapf(err, "error getting %s resource", kptfilev1.KptFileName)
 	}
-	kf, err := kptfileutil.DecodeKptfile(strings.NewReader(kfString))
+	kf, err := kptfileutil.DecodeKptfile(strings.NewReader(kfResourceMap[kptfilev1.KptFileName]))
 	if err != nil {
 		return kptfilev1.KptFile{}, pkgerrors.Wrapf(err, "error decoding %s", kptfilev1.KptFileName)
 	}

--- a/pkg/externalrepo/git/package_test.go
+++ b/pkg/externalrepo/git/package_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022, 2025 The kpt Authors
+// Copyright 2022, 2025-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,9 @@ import (
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	configapi "github.com/kptdev/porch/api/porchconfig/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -163,4 +165,92 @@ func TestPackageGetters_WithCommitInfo(t *testing.T) {
 	ts, author := gitPr.GetCommitInfo()
 	assert.Equal(t, now, ts)
 	assert.Equal(t, "user@example.com", author)
+}
+
+func (g GitSuite) TestGetFilteredResourcesReturnsAllFiles(t *testing.T) {
+	ctx, pkgRev := g.openSimpleEmptyPackage(t)
+
+	all, err := pkgRev.GetResources(ctx)
+	require.NoError(t, err)
+	got, err := pkgRev.GetFilteredResources(ctx, selector.AllFiles)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, all.Spec.Resources, got.Spec.Resources)
+	require.Contains(t, got.Spec.Resources, kptfilev1.KptFileName)
+	require.Contains(t, got.Spec.Resources, readmeFile)
+}
+
+func (g GitSuite) TestGetFilteredResourcesReturnsMatchingFiles(t *testing.T) {
+	ctx, pkgRev := g.openSimpleEmptyPackage(t)
+	all, err := pkgRev.GetResources(ctx)
+	require.NoError(t, err)
+	wantKptfile := all.Spec.Resources[kptfilev1.KptFileName]
+
+	got, err := pkgRev.GetFilteredResources(ctx, selector.PRRGet{FilePaths: []string{kptfilev1.KptFileName}})
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{kptfilev1.KptFileName: wantKptfile}, got.Spec.Resources)
+}
+
+func (g GitSuite) TestGetFilteredResourcesReturnsErrorForUnknownFile(t *testing.T) {
+	ctx, pkgRev := g.openSimpleEmptyPackage(t)
+
+	got, err := pkgRev.GetFilteredResources(ctx, selector.PRRGet{FilePaths: []string{missingPackageFile}})
+
+	require.Nil(t, got)
+	require.ErrorContains(t, err, "failed to load package resources")
+}
+
+func (g GitSuite) TestGetFilteredResourcesReturnsErrorForInvalidTree(t *testing.T) {
+	ctx, pkgRev := g.openSimpleEmptyPackage(t)
+	gitPR, ok := pkgRev.(*gitPackageRevision)
+	require.True(t, ok)
+	broken := *gitPR
+	broken.tree = plumbing.ZeroHash
+
+	got, err := broken.GetFilteredResources(ctx, selector.PRRGet{FilePaths: []string{kptfilev1.KptFileName}})
+
+	require.Nil(t, got)
+	require.ErrorContains(t, err, "failed to load package resources")
+}
+
+const (
+	simpleRepositoryTar   = "simple-repository.tar"
+	simpleRepositoryName  = "simple"
+	emptyPackageName      = "empty"
+	emptyPackageWorkspace = "v1"
+	readmeFile            = "README.md"
+	missingPackageFile    = "missing.yaml"
+)
+
+func (g GitSuite) openSimpleEmptyPackage(t *testing.T) (context.Context, repository.PackageRevision) {
+	t.Helper()
+	tempdir := t.TempDir()
+	tarfile := filepath.Join("testdata", simpleRepositoryTar)
+	_, address := ServeGitRepositoryWithBranch(t, tarfile, tempdir, g.branch)
+
+	ctx := context.Background()
+	git, err := OpenRepository(ctx, simpleRepositoryName, "default", &configapi.GitRepository{
+		Repo:      address,
+		Branch:    g.branch,
+		Directory: "/",
+	}, true, tempdir, testGitRepositoryOptions())
+	require.NoError(t, err)
+
+	revisions, err := git.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{})
+	require.NoError(t, err)
+
+	return ctx, findPackageRevision(t, revisions, repository.ListPackageRevisionFilter{
+		Key: repository.PackageRevisionKey{
+			PkgKey: repository.PackageKey{
+				RepoKey: repository.RepositoryKey{
+					Name: simpleRepositoryName,
+				},
+				Package: emptyPackageName,
+			},
+			Revision:      1,
+			WorkspaceName: emptyPackageWorkspace,
+		},
+	})
 }

--- a/pkg/externalrepo/oci/loader.go
+++ b/pkg/externalrepo/oci/loader.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kptdev/kpt/pkg/oci"
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -122,7 +123,7 @@ func (r *ociRepository) loadTasks(ctx context.Context, imageRef oci.ImageDigestN
 	return tasks, nil
 }
 
-func LoadResources(ctx context.Context, s *oci.Storage, imageName *oci.ImageDigestName) (*repository.PackageResources, error) {
+func LoadResources(ctx context.Context, s *oci.Storage, imageName *oci.ImageDigestName, selector selector.PRRGet) (*repository.PackageResources, error) {
 	ctx, span := tracer.Start(ctx, "Storage::LoadResources", trace.WithAttributes(
 		attribute.Stringer("image", imageName),
 	))
@@ -157,14 +158,14 @@ func LoadResources(ctx context.Context, s *oci.Storage, imageName *oci.ImageDige
 	tarReader := tar.NewReader(f)
 
 	// TODO: Check hash here?  Or otherwise handle error?
-	resources, err := loadResourcesFromTar(tarReader)
+	resources, err := loadResourcesFromTar(tarReader, selector)
 	if err != nil {
 		return nil, err
 	}
 	return resources, nil
 }
 
-func loadResourcesFromTar(tarReader *tar.Reader) (*repository.PackageResources, error) {
+func loadResourcesFromTar(tarReader *tar.Reader, selector selector.PRRGet) (*repository.PackageResources, error) {
 	resources := &repository.PackageResources{
 		Contents: map[string]string{},
 	}
@@ -179,6 +180,9 @@ func loadResourcesFromTar(tarReader *tar.Reader) (*repository.PackageResources, 
 		}
 		path := hdr.Name
 		fileType := hdr.FileInfo().Mode().Type()
+		if selector.MatchesFilePath(path) {
+			continue
+		}
 		switch fileType {
 		case fs.ModeDir:
 			// Ignored

--- a/pkg/externalrepo/oci/oci.go
+++ b/pkg/externalrepo/oci/oci.go
@@ -32,6 +32,7 @@ import (
 	configapi "github.com/kptdev/porch/api/porchconfig/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/kptdev/porch/pkg/util"
+	"github.com/kptdev/porch/pkg/util/selector"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -297,13 +298,25 @@ func (c *ociPackageRevision) UID() types.UID {
 }
 
 func (p *ociPackageRevision) GetResources(ctx context.Context) (*porchapi.PackageRevisionResources, error) {
-	resources, err := LoadResources(ctx, p.parent.storage, &p.digestName)
+	resources, err := LoadResources(ctx, p.parent.storage, &p.digestName, selector.AllFiles)
 	if err != nil {
 		return nil, err
 	}
 
-	key := p.Key()
+	return p.makePackageRevisionResources(resources.Contents), nil
+}
 
+func (p *ociPackageRevision) GetFilteredResources(ctx context.Context, selector selector.PRRGet) (*porchapi.PackageRevisionResources, error) {
+	resources, err := LoadResources(ctx, p.parent.storage, &p.digestName, selector)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.makePackageRevisionResources(resources.Contents), nil
+}
+
+func (p *ociPackageRevision) makePackageRevisionResources(resources map[string]string) *porchapi.PackageRevisionResources {
+	key := p.Key()
 	return &porchapi.PackageRevisionResources{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevisionResources",
@@ -324,9 +337,9 @@ func (p *ociPackageRevision) GetResources(ctx context.Context) (*porchapi.Packag
 			Revision:       key.Revision,
 			RepositoryName: key.RKey().Name,
 
-			Resources: resources.Contents,
+			Resources: resources,
 		},
-	}, nil
+	}
 }
 
 func (p *ociPackageRevision) ResourceVersion() string {
@@ -386,7 +399,7 @@ func (p *ociPackageRevision) GetPackageRevision(ctx context.Context) (*porchapi.
 }
 
 func (p *ociPackageRevision) GetKptfile(ctx context.Context) (kptfilev1.KptFile, error) {
-	resources, err := LoadResources(ctx, p.parent.storage, &p.digestName)
+	resources, err := LoadResources(ctx, p.parent.storage, &p.digestName, selector.KptFile)
 	if err != nil {
 		return kptfilev1.KptFile{}, fmt.Errorf("error loading package resources for %v: %w", p.digestName, err)
 	}

--- a/pkg/registry/porch/packagerevision_test.go
+++ b/pkg/registry/porch/packagerevision_test.go
@@ -939,10 +939,11 @@ func TestUpdate(t *testing.T) {
 // mockUpdatedObjectInfo is a mock implementation of rest.UpdatedObjectInfo
 type mockUpdatedObjectInfo struct {
 	updatedObj runtime.Object
+	err        error
 }
 
 func (m *mockUpdatedObjectInfo) UpdatedObject(ctx context.Context, oldObj runtime.Object) (runtime.Object, error) {
-	return m.updatedObj, nil
+	return m.updatedObj, m.err
 }
 
 func (m *mockUpdatedObjectInfo) Preconditions() *metav1.Preconditions {

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -19,12 +19,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kptdev/porch/api/porch"
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	porchv1alpha2 "github.com/kptdev/porch/api/porch/v1alpha2"
 	"github.com/kptdev/porch/api/porchconfig/v1alpha1"
 	"github.com/kptdev/porch/internal/telemetry"
 	"github.com/kptdev/porch/pkg/repository"
 	pctx "github.com/kptdev/porch/pkg/util/context"
+	"github.com/kptdev/porch/pkg/util/selector"
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -118,7 +120,7 @@ func (r *packageRevisionResources) List(ctx context.Context, options *metaintern
 }
 
 // Get implements the Getter interface
-func (r *packageRevisionResources) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
+func (r *packageRevisionResources) Get(ctx context.Context, rawName string, _ *metav1.GetOptions) (runtime.Object, error) {
 	ctx, span := tracer.Start(ctx, "[START]::PackageRevisionResources::Get", trace.WithAttributes())
 	start := time.Now()
 	defer func() {
@@ -127,6 +129,11 @@ func (r *packageRevisionResources) Get(ctx context.Context, name string, _ *meta
 	}()
 
 	telemetry.RecordRequestCount(ctx, prrTelemetryName, "GET", telemetry.APIVersionV1Alpha1)
+
+	name, resourceSelector, err := selector.ParsePRRGet(rawName)
+	if err != nil {
+		return nil, err
+	}
 
 	ctx = pctx.WithNewRequestIDAndPackageRevision(ctx, name)
 
@@ -138,7 +145,7 @@ func (r *packageRevisionResources) Get(ctx context.Context, name string, _ *meta
 		return nil, err
 	}
 
-	apiPkgResources, err := pkg.GetResources(ctx)
+	apiPkgResources, err := pkg.GetFilteredResources(ctx, resourceSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +158,7 @@ func (r *packageRevisionResources) Get(ctx context.Context, name string, _ *meta
 // Update finds a resource in the storage and updates it. Some implementations
 // may allow updates creates the object - they should set the created boolean
 // to true.
-func (r *packageRevisionResources) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc,
+func (r *packageRevisionResources) Update(ctx context.Context, rawName string, objInfo rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc,
 	updateValidation rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	ctx, span := tracer.Start(ctx, "[START]::PackageRevisionResources::Update", trace.WithAttributes())
 	start := time.Now()
@@ -161,6 +168,11 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 	}()
 
 	telemetry.RecordRequestCount(ctx, prrTelemetryName, "UPDATE", telemetry.APIVersionV1Alpha1)
+
+	name, resourceSelector, err := selector.ParsePRRUpdate(rawName)
+	if err != nil {
+		return nil, false, apierrors.NewBadRequest(err.Error())
+	}
 
 	ctx = pctx.WithNewRequestIDAndPackageRevision(ctx, name)
 
@@ -198,9 +210,15 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 		klog.Infof("update failed to construct UpdatedObject: %v", err)
 		return nil, false, err
 	}
-	newObj, ok := newRuntimeObj.(*porchapi.PackageRevisionResources)
-	if !ok {
-		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("expected PackageRevisionResources object, got %T", newRuntimeObj))
+	var newObj *porchapi.PackageRevisionResources
+	switch obj := newRuntimeObj.(type) {
+	case *porchapi.PackageRevisionResources:
+		newObj = obj
+	case *porch.PackageRevisionResources: // internal version
+		newObj = &porchapi.PackageRevisionResources{}
+		if err := r.scheme.Convert(obj, newObj, nil); err != nil {
+			return nil, false, apierrors.NewBadRequest(fmt.Sprintf("could not convert to external type %T", obj))
+		}
 	}
 
 	if updateValidation != nil {
@@ -237,13 +255,14 @@ func (r *packageRevisionResources) Update(ctx context.Context, name string, objI
 		}
 		r.patchRenderRequestAnnotation(ctx, namespace, name, rev.ResourceVersion())
 	} else {
-		rev, renderStatus, err = r.cad.UpdatePackageResources(ctx, &repositoryObj, oldRepoPkgRev, oldApiPkgRevResources, newObj)
+		rev, renderStatus, err = r.cad.UpdatePackageResources(ctx, &repositoryObj, oldRepoPkgRev, oldApiPkgRevResources, newObj, resourceSelector)
 		if err != nil {
 			return nil, false, apierrors.NewInternalError(err)
 		}
 	}
 
-	created, err := rev.GetResources(ctx)
+	//created, err := rev.GetResources(ctx)
+	created, err := r.makeResult(ctx, rev, oldApiPkgRevResources.Spec.Resources, newObj.Spec.Resources, resourceSelector)
 	if err != nil {
 		return nil, false, apierrors.NewInternalError(err)
 	}
@@ -315,4 +334,32 @@ func (r *packageRevisionResources) getRepoPkgRevForResources(ctx context.Context
 	}
 
 	return nil, apierrors.NewNotFound(r.gr, name)
+}
+
+func (r *packageRevisionResources) makeResult(ctx context.Context, rev repository.PackageRevision, oldResources, newResources map[string]string, resourceSelector selector.PRRUpdate) (*porchapi.PackageRevisionResources, error) {
+	if resourceSelector.Partial {
+		newFiles := selector.PRRGet{FilePaths: make([]string, len(newResources))}
+		for filePath := range newResources {
+			newFiles.FilePaths = append(newFiles.FilePaths, filePath)
+		}
+		updated, err := rev.GetFilteredResources(ctx, newFiles)
+		if err != nil {
+			return nil, err
+		}
+		updated.Spec.Resources = r.diffNewAndChanged(oldResources, updated.Spec.Resources)
+
+		return updated, nil
+	}
+
+	return rev.GetResources(ctx)
+}
+
+func (r *packageRevisionResources) diffNewAndChanged(old, new map[string]string) map[string]string {
+	result := make(map[string]string)
+	for kNew, vNew := range new {
+		if vOld, ok := old[kNew]; !ok || vOld != vNew {
+			result[kNew] = vNew
+		}
+	}
+	return result
 }

--- a/pkg/registry/porch/packagerevisionresources.go
+++ b/pkg/registry/porch/packagerevisionresources.go
@@ -132,7 +132,7 @@ func (r *packageRevisionResources) Get(ctx context.Context, rawName string, _ *m
 
 	name, resourceSelector, err := selector.ParsePRRGet(rawName)
 	if err != nil {
-		return nil, err
+		return nil, apierrors.NewBadRequest(err.Error())
 	}
 
 	ctx = pctx.WithNewRequestIDAndPackageRevision(ctx, name)
@@ -246,6 +246,7 @@ func (r *packageRevisionResources) Update(ctx context.Context, rawName string, o
 
 	var rev repository.PackageRevision
 	var renderStatus *porchapi.RenderStatus
+	submittedFiles := filePathsOf(newObj.Spec.Resources)
 
 	if isV1Alpha2Repo(&repositoryObj) {
 		// v1alpha2: write resources without render. PR controller renders async.
@@ -261,8 +262,7 @@ func (r *packageRevisionResources) Update(ctx context.Context, rawName string, o
 		}
 	}
 
-	//created, err := rev.GetResources(ctx)
-	created, err := r.makeResult(ctx, rev, oldApiPkgRevResources.Spec.Resources, newObj.Spec.Resources, resourceSelector)
+	created, err := r.makeResult(ctx, rev, oldApiPkgRevResources.Spec.Resources, submittedFiles, resourceSelector)
 	if err != nil {
 		return nil, false, apierrors.NewInternalError(err)
 	}
@@ -336,13 +336,9 @@ func (r *packageRevisionResources) getRepoPkgRevForResources(ctx context.Context
 	return nil, apierrors.NewNotFound(r.gr, name)
 }
 
-func (r *packageRevisionResources) makeResult(ctx context.Context, rev repository.PackageRevision, oldResources, newResources map[string]string, resourceSelector selector.PRRUpdate) (*porchapi.PackageRevisionResources, error) {
+func (r *packageRevisionResources) makeResult(ctx context.Context, rev repository.PackageRevision, oldResources map[string]string, submittedFiles selector.PRRGet, resourceSelector selector.PRRUpdate) (*porchapi.PackageRevisionResources, error) {
 	if resourceSelector.Partial {
-		newFiles := selector.PRRGet{FilePaths: make([]string, len(newResources))}
-		for filePath := range newResources {
-			newFiles.FilePaths = append(newFiles.FilePaths, filePath)
-		}
-		updated, err := rev.GetFilteredResources(ctx, newFiles)
+		updated, err := rev.GetFilteredResources(ctx, submittedFiles)
 		if err != nil {
 			return nil, err
 		}
@@ -352,6 +348,14 @@ func (r *packageRevisionResources) makeResult(ctx context.Context, rev repositor
 	}
 
 	return rev.GetResources(ctx)
+}
+
+func filePathsOf(resources map[string]string) selector.PRRGet {
+	filePaths := make([]string, 0, len(resources))
+	for filePath := range resources {
+		filePaths = append(filePaths, filePath)
+	}
+	return selector.PRRGet{FilePaths: filePaths}
 }
 
 func (r *packageRevisionResources) diffNewAndChanged(old, new map[string]string) map[string]string {

--- a/pkg/registry/porch/packagerevisionresources_test.go
+++ b/pkg/registry/porch/packagerevisionresources_test.go
@@ -126,13 +126,13 @@ func TestGetResources(t *testing.T) {
 
 	//=========================================================================================
 
-	// Error from GetResources
+	// Error from GetFilteredResources
 	mockPkgRev := mockrepo.NewMockPackageRevision(t)
 	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
 		mockPkgRev,
 	}, nil).Once()
 	mockPkgRev.On("KubeObjectName").Return(pkgRevName)
-	mockPkgRev.On("GetResources", mock.Anything).Return(nil, errors.New("error getting resources"))
+	mockPkgRev.On("GetFilteredResources", mock.Anything, mock.Anything).Return(nil, errors.New("error getting resources"))
 
 	result, err = packagerevisionresources.Get(ctx, pkgRevName, nil)
 	assert.Error(t, err)

--- a/pkg/registry/porch/packagerevisionresources_test.go
+++ b/pkg/registry/porch/packagerevisionresources_test.go
@@ -17,17 +17,22 @@ package porch
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
+	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	configapi "github.com/kptdev/porch/api/porchconfig/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	mockclient "github.com/kptdev/porch/test/mockery/mocks/external/sigs.k8s.io/controller-runtime/pkg/client"
 	mockengine "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/engine"
 	mockrepo "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -137,4 +142,145 @@ func TestGetResources(t *testing.T) {
 	result, err = packagerevisionresources.Get(ctx, pkgRevName, nil)
 	assert.Error(t, err)
 	assert.Nil(t, result)
+}
+
+func TestUpdatePartialResultUsesSubmittedFiles(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Repository"), mock.Anything).Return(nil)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	pkgRevName := "repo.1234567890.ws"
+	oldKptfile := "old-kptfile"
+	oldReadme := "old-readme"
+	oldDeploy := "old-deploy"
+	renderedKptfile := "rendered-kptfile"
+	oldResources := &porchapi.PackageRevisionResources{
+		Spec: porchapi.PackageRevisionResourcesSpec{
+			Resources: map[string]string{
+				kptfilev1.KptFileName: oldKptfile,
+				"README.md":           oldReadme,
+				"deploy.yaml":         oldDeploy,
+			},
+		},
+	}
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{
+		mockPkgRev,
+	}, nil)
+	mockPkgRev.On("KubeObjectName").Return(pkgRevName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(oldResources, nil)
+	mockEngine.On("UpdatePackageResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, selector.Partial).
+		Run(func(args mock.Arguments) {
+			newRes := args.Get(4).(*porchapi.PackageRevisionResources)
+			newRes.Spec.Resources = map[string]string{
+				kptfilev1.KptFileName: "merged-kptfile",
+				"README.md":           oldReadme,
+				"deploy.yaml":         "changed-by-render",
+			}
+		}).
+		Return(mockPkgRev, (*porchapi.RenderStatus)(nil), nil)
+	mockPkgRev.On("GetFilteredResources", mock.Anything, matchPRRGetFiles(kptfilev1.KptFileName)).
+		Return(&porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: map[string]string{
+					kptfilev1.KptFileName: renderedKptfile,
+				},
+			},
+		}, nil)
+	objInfo := &mockUpdatedObjectInfo{
+		updatedObj: &porchapi.PackageRevisionResources{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pkgRevName,
+			},
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: map[string]string{
+					kptfilev1.KptFileName: "client-kptfile",
+				},
+			},
+		},
+	}
+	ctx := genericapirequest.WithNamespace(context.TODO(), "someDummyNamespace")
+
+	// when
+	result, created, err := packagerevisionresources.Update(ctx, pkgRevName+"?partial=true", objInfo, nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.NoError(t, err)
+	require.False(t, created)
+	updated, ok := result.(*porchapi.PackageRevisionResources)
+	require.True(t, ok)
+	require.Equal(t, map[string]string{kptfilev1.KptFileName: renderedKptfile}, updated.Spec.Resources)
+}
+
+func TestMakeResultPartialUpdateReturnsChangedSubmittedFiles(t *testing.T) {
+	// given
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	oldResources := map[string]string{
+		kptfilev1.KptFileName: "old-kptfile",
+		"README.md":           "old-readme",
+	}
+	submittedFiles := selector.PRRGet{FilePaths: []string{kptfilev1.KptFileName}}
+	mockPkgRev.On("GetFilteredResources", mock.Anything, matchPRRGetFiles(kptfilev1.KptFileName)).
+		Return(&porchapi.PackageRevisionResources{
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: map[string]string{
+					kptfilev1.KptFileName: "new-kptfile",
+				},
+			},
+		}, nil)
+
+	// when
+	result, err := packagerevisionresources.makeResult(context.Background(), mockPkgRev, oldResources, submittedFiles, selector.Partial)
+
+	// then
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{kptfilev1.KptFileName: "new-kptfile"}, result.Spec.Resources)
+}
+
+func TestMakeResultPartialUpdateFailsWhenGetFilteredResourcesFails(t *testing.T) {
+	// given
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	submittedFiles := selector.PRRGet{FilePaths: []string{kptfilev1.KptFileName}}
+	mockPkgRev.On("GetFilteredResources", mock.Anything, matchPRRGetFiles(kptfilev1.KptFileName)).
+		Return(nil, errors.New("filter failed"))
+
+	// when
+	result, err := packagerevisionresources.makeResult(context.Background(), mockPkgRev, nil, submittedFiles, selector.Partial)
+
+	// then
+	require.Nil(t, result)
+	require.ErrorContains(t, err, "filter failed")
+}
+
+func TestMakeResultCompleteUpdateReturnsAllResources(t *testing.T) {
+	// given
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	allResources := &porchapi.PackageRevisionResources{
+		Spec: porchapi.PackageRevisionResourcesSpec{
+			Resources: map[string]string{
+				kptfilev1.KptFileName: "kptfile",
+				"README.md":           "readme",
+			},
+		},
+	}
+	mockPkgRev.On("GetResources", mock.Anything).Return(allResources, nil)
+
+	// when
+	result, err := packagerevisionresources.makeResult(context.Background(), mockPkgRev, nil, selector.PRRGet{}, selector.Complete)
+
+	// then
+	require.NoError(t, err)
+	require.Equal(t, allResources, result)
+}
+
+func matchPRRGetFiles(want ...string) interface{} {
+	return mock.MatchedBy(func(got selector.PRRGet) bool {
+		if len(got.FilePaths) != len(want) {
+			return false
+		}
+		sortedGot := slices.Clone(got.FilePaths)
+		sortedWant := slices.Clone(want)
+		slices.Sort(sortedGot)
+		slices.Sort(sortedWant)
+		return slices.Equal(sortedGot, sortedWant)
+	})
 }

--- a/pkg/registry/porch/packagerevisionresources_update_test.go
+++ b/pkg/registry/porch/packagerevisionresources_update_test.go
@@ -1,0 +1,640 @@
+// Copyright 2026 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
+	apiporch "github.com/kptdev/porch/api/porch"
+	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
+	porchv1alpha2 "github.com/kptdev/porch/api/porch/v1alpha2"
+	configapi "github.com/kptdev/porch/api/porchconfig/v1alpha1"
+	"github.com/kptdev/porch/pkg/repository"
+	mockclient "github.com/kptdev/porch/test/mockery/mocks/external/sigs.k8s.io/controller-runtime/pkg/client"
+	mockengine "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/engine"
+	mockrepo "github.com/kptdev/porch/test/mockery/mocks/porch/pkg/repository"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testPRRNamespace       = "someDummyNamespace"
+	testPRRName            = "repo.1234567890.ws"
+	testPRRResourceVersion = "rv-42"
+	testReadmeFile         = "README.md"
+	testDeployFile         = "deploy.yaml"
+)
+
+func TestUpdateRejectsInvalidPartialQuery(t *testing.T) {
+	// given
+	setupResourcesTest(t)
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName+"?partial=true&partial=false",
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "kptfile"}),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.True(t, apierrors.IsBadRequest(err))
+	require.ErrorContains(t, err, "multiple partial values found")
+}
+
+func TestUpdateRequiresNamespace(t *testing.T) {
+	// given
+	setupResourcesTest(t)
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		context.TODO(),
+		testPRRName,
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "kptfile"}),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.True(t, apierrors.IsBadRequest(err))
+	require.ErrorContains(t, err, "namespace must be specified")
+}
+
+func TestUpdateReturnsConflictWhenPackageIsLocked(t *testing.T) {
+	// given
+	setupResourcesTest(t)
+	lockedName := "repo.locked-pkg.ws"
+	pkgMutex := getMutexForPackage(getPackageMutexKey(testPRRNamespace, lockedName))
+	pkgMutex.Lock()
+	defer pkgMutex.Unlock()
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		lockedName,
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "kptfile"}),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.True(t, apierrors.IsConflict(err))
+	require.ErrorContains(t, err, "already in progress")
+}
+
+func TestUpdateReturnsErrorWhenPackageRevisionNotFound(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	stubRepositoryGet(mockClient, nil)
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{}, nil)
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "kptfile"}),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func TestUpdateReturnsErrorWhenGetResourcesFails(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	stubRepositoryGet(mockClient, nil)
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(nil, errors.New("read failed"))
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "kptfile"}),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.ErrorContains(t, err, "read failed")
+}
+
+func TestUpdateReturnsErrorWhenUpdatedObjectFails(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	stubRepositoryGet(mockClient, nil)
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(testPRRResources(map[string]string{kptfilev1.KptFileName: "old"}), nil)
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		&mockUpdatedObjectInfo{err: errors.New("cannot build updated object")},
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.ErrorContains(t, err, "cannot build updated object")
+}
+
+func TestUpdateReturnsErrorWhenValidationFails(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	stubRepositoryGet(mockClient, nil)
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(testPRRResources(map[string]string{kptfilev1.KptFileName: "old"}), nil)
+	validate := func(context.Context, runtime.Object, runtime.Object) error {
+		return errors.New("validation failed")
+	}
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "new"}),
+		nil, validate, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.ErrorContains(t, err, "validation failed")
+}
+
+func TestUpdateReturnsNotFoundWhenRepositoryIsMissing(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(testPRRResources(map[string]string{kptfilev1.KptFileName: "old"}), nil)
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Repository"), mock.Anything).
+		Return(nil).Once()
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Repository"), mock.Anything).
+		Return(apierrors.NewNotFound(configapi.TypeRepository.GroupResource(), "repo")).Once()
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "new"}),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func TestUpdateReturnsInternalErrorWhenRepositoryGetFails(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(testPRRResources(map[string]string{kptfilev1.KptFileName: "old"}), nil)
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Repository"), mock.Anything).
+		Return(nil).Once()
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Repository"), mock.Anything).
+		Return(errors.New("etcd unavailable")).Once()
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "new"}),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.True(t, apierrors.IsInternalError(err))
+	require.ErrorContains(t, err, "etcd unavailable")
+}
+
+func TestUpdateReturnsInternalErrorWhenEngineUpdateFails(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	stubRepositoryGet(mockClient, nil)
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(testPRRResources(map[string]string{kptfilev1.KptFileName: "old"}), nil)
+	mockEngine.On("UpdatePackageResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, (*porchapi.RenderStatus)(nil), errors.New("engine update failed"))
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "new"}),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.True(t, apierrors.IsInternalError(err))
+	require.ErrorContains(t, err, "engine update failed")
+}
+
+func TestUpdateReturnsInternalErrorWhenMakeResultFails(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	oldResources := testPRRResources(map[string]string{kptfilev1.KptFileName: "old"})
+	stubRepositoryGet(mockClient, nil)
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(oldResources, nil).Once()
+	mockEngine.On("UpdatePackageResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mockPkgRev, (*porchapi.RenderStatus)(nil), nil)
+	mockPkgRev.On("GetResources", mock.Anything).Return(nil, errors.New("result load failed")).Once()
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "new"}),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.True(t, apierrors.IsInternalError(err))
+	require.ErrorContains(t, err, "result load failed")
+}
+
+func TestUpdateCompleteReplaceReturnsAllResourcesAndRenderStatus(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	updatedResources := testPRRResources(map[string]string{
+		kptfilev1.KptFileName: "new-kptfile",
+		testReadmeFile:        "new-readme",
+	})
+	renderStatus := &porchapi.RenderStatus{Err: "render warning"}
+	stubRepositoryGet(mockClient, nil)
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(testPRRResources(map[string]string{kptfilev1.KptFileName: "old"}), nil).Once()
+	mockEngine.On("UpdatePackageResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mockPkgRev, renderStatus, nil)
+	mockPkgRev.On("GetResources", mock.Anything).Return(updatedResources, nil).Once()
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		testUpdatedObjectInfo(updatedResources.Spec.Resources),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.NoError(t, err)
+	require.False(t, created)
+	updated, ok := result.(*porchapi.PackageRevisionResources)
+	require.True(t, ok)
+	require.Equal(t, updatedResources.Spec.Resources, updated.Spec.Resources)
+	require.Equal(t, "render warning", updated.Status.RenderStatus.Err)
+}
+
+func TestUpdateConvertsInternalPackageRevisionResources(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	stubRepositoryGet(mockClient, nil)
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(testPRRResources(map[string]string{kptfilev1.KptFileName: "old"}), nil)
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		&mockUpdatedObjectInfo{
+			updatedObj: &apiporch.PackageRevisionResources{
+				Spec: apiporch.PackageRevisionResourcesSpec{
+					Resources: map[string]string{kptfilev1.KptFileName: "new"},
+				},
+			},
+		},
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.True(t, apierrors.IsBadRequest(err))
+	require.ErrorContains(t, err, "could not convert to external type")
+}
+
+func TestUpdateV1Alpha2WritesWithoutRenderAndPatchesAnnotation(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	updatedResources := testPRRResources(map[string]string{kptfilev1.KptFileName: "new-kptfile"})
+	stubRepositoryGet(mockClient, v1alpha2Repository())
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(testPRRResources(map[string]string{kptfilev1.KptFileName: "old"}), nil).Once()
+	mockEngine.On("UpdatePackageResourcesWithoutRender", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mockPkgRev, nil)
+	mockPkgRev.On("ResourceVersion").Return(testPRRResourceVersion)
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha2.PackageRevision"), mock.Anything).
+		Run(func(args mock.Arguments) {
+			pr := args.Get(2).(*porchv1alpha2.PackageRevision)
+			pr.Name = testPRRName
+			pr.Namespace = testPRRNamespace
+		}).Return(nil)
+	mockClient.On("Patch", mock.Anything, mock.AnythingOfType("*v1alpha2.PackageRevision"), mock.Anything).
+		Run(func(args mock.Arguments) {
+			pr := args.Get(1).(*porchv1alpha2.PackageRevision)
+			require.Equal(t, testPRRResourceVersion, pr.Annotations[porchv1alpha2.AnnotationRenderRequest])
+		}).Return(nil)
+	mockPkgRev.On("GetResources", mock.Anything).Return(updatedResources, nil).Once()
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		testUpdatedObjectInfo(updatedResources.Spec.Resources),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.NoError(t, err)
+	require.False(t, created)
+	updated, ok := result.(*porchapi.PackageRevisionResources)
+	require.True(t, ok)
+	require.Equal(t, updatedResources.Spec.Resources, updated.Spec.Resources)
+	mockEngine.AssertNotCalled(t, "UpdatePackageResources")
+	mockClient.AssertCalled(t, "Patch", mock.Anything, mock.AnythingOfType("*v1alpha2.PackageRevision"), mock.Anything)
+}
+
+func TestUpdateV1Alpha2ReturnsInternalErrorWhenEngineUpdateFails(t *testing.T) {
+	// given
+	mockClient, mockEngine := setupResourcesTest(t)
+	mockPkgRev := mockrepo.NewMockPackageRevision(t)
+	stubRepositoryGet(mockClient, v1alpha2Repository())
+	stubListedPackageRevision(mockEngine, mockPkgRev, testPRRName)
+	mockPkgRev.On("GetResources", mock.Anything).Return(testPRRResources(map[string]string{kptfilev1.KptFileName: "old"}), nil)
+	mockEngine.On("UpdatePackageResourcesWithoutRender", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, errors.New("v1alpha2 write failed"))
+
+	// when
+	result, created, err := packagerevisionresources.Update(
+		namespacedPRRContext(),
+		testPRRName,
+		testUpdatedObjectInfo(map[string]string{kptfilev1.KptFileName: "new"}),
+		nil, nil, false, &metav1.UpdateOptions{})
+
+	// then
+	require.Nil(t, result)
+	require.False(t, created)
+	require.True(t, apierrors.IsInternalError(err))
+	require.ErrorContains(t, err, "v1alpha2 write failed")
+}
+
+func TestDiffNewAndChanged(t *testing.T) {
+	tests := []struct {
+		name string
+		old  map[string]string
+		new  map[string]string
+		want map[string]string
+	}{
+		{
+			name: "includes changed and added files",
+			old: map[string]string{
+				kptfilev1.KptFileName: "old-kptfile",
+				testReadmeFile:        "old-readme",
+			},
+			new: map[string]string{
+				kptfilev1.KptFileName: "new-kptfile",
+				testReadmeFile:        "old-readme",
+				testDeployFile:        "added-deploy",
+			},
+			want: map[string]string{
+				kptfilev1.KptFileName: "new-kptfile",
+				testDeployFile:        "added-deploy",
+			},
+		},
+		{
+			name: "omits unchanged files",
+			old: map[string]string{
+				kptfilev1.KptFileName: "same",
+			},
+			new: map[string]string{
+				kptfilev1.KptFileName: "same",
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "omits files only present in the old package",
+			old: map[string]string{
+				kptfilev1.KptFileName: "kptfile",
+				testReadmeFile:        "readme",
+			},
+			new: map[string]string{
+				kptfilev1.KptFileName: "kptfile",
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "treats all files as added when old map is nil",
+			old:  nil,
+			new: map[string]string{
+				kptfilev1.KptFileName: "kptfile",
+			},
+			want: map[string]string{
+				kptfilev1.KptFileName: "kptfile",
+			},
+		},
+		{
+			name: "returns empty map when new map is empty",
+			old: map[string]string{
+				kptfilev1.KptFileName: "kptfile",
+			},
+			new:  map[string]string{},
+			want: map[string]string{},
+		},
+		{
+			name: "returns empty map when new map is nil",
+			old: map[string]string{
+				kptfilev1.KptFileName: "kptfile",
+			},
+			new:  nil,
+			want: map[string]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			// when
+			got := packagerevisionresources.diffNewAndChanged(tc.old, tc.new)
+
+			// then
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPatchRenderRequestAnnotationSetsAnnotation(t *testing.T) {
+	// given
+	pr := v1alpha2PackageRevision(nil)
+	storage, fakeClient := newPRRStorageWithFakeClient(t, pr)
+
+	// when
+	storage.patchRenderRequestAnnotation(context.Background(), testPRRNamespace, testPRRName, testPRRResourceVersion)
+
+	// then
+	got := &porchv1alpha2.PackageRevision{}
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: testPRRNamespace, Name: testPRRName}, got))
+	require.Equal(t, testPRRResourceVersion, got.Annotations[porchv1alpha2.AnnotationRenderRequest])
+}
+
+func TestPatchRenderRequestAnnotationPreservesOtherAnnotations(t *testing.T) {
+	// given
+	pr := v1alpha2PackageRevision(map[string]string{"keep": "me"})
+	storage, fakeClient := newPRRStorageWithFakeClient(t, pr)
+
+	// when
+	storage.patchRenderRequestAnnotation(context.Background(), testPRRNamespace, testPRRName, testPRRResourceVersion)
+
+	// then
+	got := &porchv1alpha2.PackageRevision{}
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: testPRRNamespace, Name: testPRRName}, got))
+	require.Equal(t, "me", got.Annotations["keep"])
+	require.Equal(t, testPRRResourceVersion, got.Annotations[porchv1alpha2.AnnotationRenderRequest])
+}
+
+func TestPatchRenderRequestAnnotationOverwritesExistingRenderRequest(t *testing.T) {
+	// given
+	pr := v1alpha2PackageRevision(map[string]string{porchv1alpha2.AnnotationRenderRequest: "old-rv"})
+	storage, fakeClient := newPRRStorageWithFakeClient(t, pr)
+
+	// when
+	storage.patchRenderRequestAnnotation(context.Background(), testPRRNamespace, testPRRName, testPRRResourceVersion)
+
+	// then
+	got := &porchv1alpha2.PackageRevision{}
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: testPRRNamespace, Name: testPRRName}, got))
+	require.Equal(t, testPRRResourceVersion, got.Annotations[porchv1alpha2.AnnotationRenderRequest])
+}
+
+func TestPatchRenderRequestAnnotationIgnoresMissingPackageRevision(t *testing.T) {
+	// given
+	storage, fakeClient := newPRRStorageWithFakeClient(t)
+
+	// when
+	storage.patchRenderRequestAnnotation(context.Background(), testPRRNamespace, testPRRName, testPRRResourceVersion)
+
+	// then
+	list := &porchv1alpha2.PackageRevisionList{}
+	require.NoError(t, fakeClient.List(context.Background(), list))
+	require.Empty(t, list.Items)
+}
+
+func TestPatchRenderRequestAnnotationIgnoresPatchFailure(t *testing.T) {
+	// given
+	mockClient := mockclient.NewMockClient(t)
+	storage := &packageRevisionResources{
+		packageCommon: packageCommon{coreClient: mockClient},
+	}
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha2.PackageRevision"), mock.Anything).Return(nil)
+	mockClient.On("Patch", mock.Anything, mock.AnythingOfType("*v1alpha2.PackageRevision"), mock.Anything).
+		Return(errors.New("patch failed"))
+
+	// when
+	storage.patchRenderRequestAnnotation(context.Background(), testPRRNamespace, testPRRName, testPRRResourceVersion)
+
+	// then
+	mockClient.AssertCalled(t, "Patch", mock.Anything, mock.AnythingOfType("*v1alpha2.PackageRevision"), mock.Anything)
+}
+
+func namespacedPRRContext() context.Context {
+	return genericapirequest.WithNamespace(context.TODO(), testPRRNamespace)
+}
+
+func testPRRResources(resources map[string]string) *porchapi.PackageRevisionResources {
+	return &porchapi.PackageRevisionResources{
+		Spec: porchapi.PackageRevisionResourcesSpec{
+			Resources: resources,
+		},
+	}
+}
+
+func testUpdatedObjectInfo(resources map[string]string) rest.UpdatedObjectInfo {
+	return &mockUpdatedObjectInfo{
+		updatedObj: &porchapi.PackageRevisionResources{
+			ObjectMeta: metav1.ObjectMeta{Name: testPRRName},
+			Spec: porchapi.PackageRevisionResourcesSpec{
+				Resources: resources,
+			},
+		},
+	}
+}
+
+func stubRepositoryGet(mockClient *mockclient.MockClient, repo *configapi.Repository) {
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Repository"), mock.Anything).
+		Run(func(args mock.Arguments) {
+			dest := args.Get(2).(*configapi.Repository)
+			if repo != nil {
+				*dest = *repo.DeepCopy()
+			}
+		}).Return(nil)
+}
+
+func stubListedPackageRevision(mockEngine *mockengine.MockCaDEngine, mockPkgRev *mockrepo.MockPackageRevision, name string) {
+	mockEngine.On("ListPackageRevisions", mock.Anything, mock.Anything).Return([]repository.PackageRevision{mockPkgRev}, nil)
+	mockPkgRev.On("KubeObjectName").Return(name)
+}
+
+func v1alpha2Repository() *configapi.Repository {
+	return &configapi.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				configapi.AnnotationKeyV1Alpha2Migration: configapi.AnnotationValueMigrationEnabled,
+			},
+		},
+	}
+}
+
+func v1alpha2PackageRevision(annotations map[string]string) *porchv1alpha2.PackageRevision {
+	return &porchv1alpha2.PackageRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testPRRName,
+			Namespace:   testPRRNamespace,
+			Annotations: annotations,
+		},
+	}
+}
+
+func newPRRStorageWithFakeClient(t *testing.T, objects ...client.Object) (*packageRevisionResources, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, porchv1alpha2.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	return &packageRevisionResources{
+		packageCommon: packageCommon{coreClient: fakeClient},
+	}, fakeClient
+}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -27,6 +27,7 @@ import (
 	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	"github.com/kptdev/porch/pkg/util"
+	"github.com/kptdev/porch/pkg/util/selector"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -274,6 +275,9 @@ type PackageRevision interface {
 	// GetResources returns the PackageRevisionResources ("WET") API representation of this package-revision
 	// TODO: return PackageResources or filesystem abstraction?
 	GetResources(ctx context.Context) (*porchapi.PackageRevisionResources, error)
+
+	// GetFilteredResources returns the filtered PackageRevisionResources ("WET") API representation of this package-revision
+	GetFilteredResources(ctx context.Context, resourceSelector selector.PRRGet) (*porchapi.PackageRevisionResources, error)
 
 	// GetUpstreamLock returns the kpt lock information.
 	GetUpstreamLock(ctx context.Context) (kptfilev1.Upstream, kptfilev1.Locator, error)

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -23,6 +23,7 @@ import (
 
 	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
+	"github.com/kptdev/porch/pkg/util/selector"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -490,6 +491,9 @@ func (f *fakePackageRevision) Lifecycle(context.Context) porchapi.PackageRevisio
 	return porchapi.PackageRevisionLifecycle(f.lifecycle)
 }
 func (f *fakePackageRevision) GetResources(context.Context) (*porchapi.PackageRevisionResources, error) {
+	return nil, nil
+}
+func (f *fakePackageRevision) GetFilteredResources(context.Context, selector.PRRGet) (*porchapi.PackageRevisionResources, error) {
 	return nil, nil
 }
 func (f *fakePackageRevision) UpdateLifecycle(context.Context, porchapi.PackageRevisionLifecycle) error {

--- a/pkg/util/selector/prr_selector.go
+++ b/pkg/util/selector/prr_selector.go
@@ -1,0 +1,80 @@
+package selector
+
+import (
+	neturl "net/url"
+	"slices"
+	"strings"
+
+	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
+	pkgerrors "github.com/pkg/errors"
+)
+
+const (
+	fileQueryKey    = "file"
+	partialQueryKey = "partial"
+)
+
+var AllFiles = PRRGet{}
+var NoFiles = PRRGet{FilePaths: []string{}}
+var KptFile = PRRGet{FilePaths: []string{kptfilev1.KptFileName}}
+var Partial = PRRUpdate{Partial: true}
+var Complete = PRRUpdate{Partial: false}
+
+type PRRGet struct {
+	FilePaths []string
+}
+
+type PRRUpdate struct {
+	Partial bool
+}
+
+func (s *PRRGet) IsAllFiles() bool {
+	return s.FilePaths == nil
+}
+
+func (s *PRRGet) MatchesFilePath(filePath string) bool {
+	return s.IsAllFiles() || slices.Contains(s.FilePaths, filePath)
+}
+
+func ParsePRRGet(rawName string) (packageRevisionName string, selector PRRGet, err error) {
+	packageRevisionName, queryValues, err := parseRawName(rawName)
+	if err != nil {
+		return "", PRRGet{}, err
+	}
+	files := queryValues[fileQueryKey]
+	return packageRevisionName, PRRGet{
+		FilePaths: files,
+	}, nil
+}
+
+func ParsePRRUpdate(rawName string) (packageRevisionName string, selector PRRUpdate, err error) {
+	packageRevisionName, queryValues, err := parseRawName(rawName)
+	if err != nil {
+		return "", PRRUpdate{}, err
+	}
+	partial := false
+	if partialValues, existPartialKey := queryValues[partialQueryKey]; existPartialKey {
+		if len(partialValues) > 1 {
+			return "", PRRUpdate{}, pkgerrors.New("multiple partial values found")
+		}
+		if slices.Contains([]string{"YES", "TRUE", "1", ""}, strings.ToUpper(partialValues[0])) {
+			partial = true
+		}
+	}
+	return packageRevisionName, PRRUpdate{
+		Partial: partial,
+	}, nil
+}
+
+func parseRawName(rawName string) (resourceName string, queryValues neturl.Values, err error) {
+	url, err := neturl.Parse(rawName)
+	if err != nil {
+		return rawName, nil, pkgerrors.Wrap(err, "failed to parse raw name")
+	}
+	resourceName = url.Path
+	queryValues, err = neturl.ParseQuery(url.RawQuery)
+	if err != nil {
+		return resourceName, nil, pkgerrors.Wrap(err, "failed to parse query string")
+	}
+	return
+}

--- a/pkg/util/selector/prr_selector_test.go
+++ b/pkg/util/selector/prr_selector_test.go
@@ -1,0 +1,181 @@
+package selector
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPRName     = "repo.package.v1"
+	testKptFile    = "Kptfile"
+	testReadmeFile = "README.md"
+)
+
+func TestParseGetPackageRevisionResourcesUrl(t *testing.T) {
+	testCases := map[string]struct {
+		nameWithQuery               string
+		expectedPackageRevisionName string
+		expectedSelector            PRRGet
+		expectedErr                 string
+	}{
+		"no name": {
+			nameWithQuery:               "",
+			expectedPackageRevisionName: "",
+			expectedSelector: PRRGet{
+				FilePaths: nil,
+			},
+			expectedErr: "",
+		},
+		"no selector": {
+			nameWithQuery:               testPRName,
+			expectedPackageRevisionName: testPRName,
+			expectedSelector: PRRGet{
+				FilePaths: nil,
+			},
+			expectedErr: "",
+		},
+		"empty selector": {
+			nameWithQuery:               fmt.Sprintf("%s?", testPRName),
+			expectedPackageRevisionName: testPRName,
+			expectedSelector: PRRGet{
+				FilePaths: nil,
+			},
+			expectedErr: "",
+		},
+		"file selector": {
+			nameWithQuery:               fmt.Sprintf("%s?file=%s", testPRName, testKptFile),
+			expectedPackageRevisionName: testPRName,
+			expectedSelector: PRRGet{
+				FilePaths: []string{testKptFile},
+			},
+			expectedErr: "",
+		},
+		"partial selector": {
+			nameWithQuery:               fmt.Sprintf("%s?partial=false", testPRName),
+			expectedPackageRevisionName: testPRName,
+			expectedSelector: PRRGet{
+				FilePaths: nil,
+			},
+			expectedErr: "",
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			// when
+			packageRevisionName, selector, err := ParsePRRGet(tc.nameWithQuery)
+
+			// then
+			assert.Equal(t, tc.expectedPackageRevisionName, packageRevisionName, "expected package revision name does not match")
+			assert.Equal(t, tc.expectedSelector, selector, "expected selector does not match")
+			if tc.expectedErr == "" {
+				require.NoError(t, err, "expected no error")
+			} else {
+				require.Equal(t, tc.expectedErr, err.Error(), "expected error does not match")
+			}
+		})
+	}
+}
+
+func TestParseUpdatePackageRevisionResourcesUrl(t *testing.T) {
+	testCases := map[string]struct {
+		nameWithQuery               string
+		expectedPackageRevisionName string
+		expectedSelector            PRRUpdate
+		expectedErr                 string
+	}{
+		"multiple selector": {
+			nameWithQuery:               fmt.Sprintf("%s?file=%s&file=%s&partial=true", testPRName, testKptFile, testReadmeFile),
+			expectedPackageRevisionName: testPRName,
+			expectedSelector: PRRUpdate{
+				Partial: true,
+			},
+			expectedErr: "",
+		},
+		"separator not exist in item": {
+			nameWithQuery:               fmt.Sprintf("%s?partial", testPRName),
+			expectedPackageRevisionName: testPRName,
+			expectedSelector: PRRUpdate{
+				Partial: true,
+			},
+			expectedErr: "",
+		},
+		"duplicate key in selector error": {
+			nameWithQuery:               fmt.Sprintf("%s?partial=true&partial=false", testPRName),
+			expectedPackageRevisionName: "",
+			expectedSelector:            PRRUpdate{},
+			expectedErr:                 "multiple partial values found",
+		},
+		"parse query string error": {
+			nameWithQuery:               "repo.package.v1?file=Kptfile%partial=false",
+			expectedPackageRevisionName: "",
+			expectedSelector:            PRRUpdate{},
+			expectedErr:                 "failed to parse query string: invalid URL escape \"%pa\"",
+		},
+		"parse url error": {
+			nameWithQuery:               "repo.package.v1%partial",
+			expectedPackageRevisionName: "",
+			expectedSelector:            PRRUpdate{},
+			expectedErr:                 "failed to parse raw name: parse \"repo.package.v1%partial\": invalid URL escape \"%pa\"",
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			// when
+			packageRevisionName, selector, err := ParsePRRUpdate(tc.nameWithQuery)
+
+			// then
+			assert.Equal(t, tc.expectedPackageRevisionName, packageRevisionName, "expected package revision name does not match")
+			assert.Equal(t, tc.expectedSelector, selector, "expected selector does not match")
+			if tc.expectedErr == "" {
+				require.NoError(t, err, "expected no error")
+			} else {
+				require.Equal(t, tc.expectedErr, err.Error(), "expected error does not match")
+			}
+		})
+	}
+}
+
+func TestPRRGetIsMatchFilePath(t *testing.T) {
+	testCases := map[string]struct {
+		selector      PRRGet
+		match         string
+		expectedMatch bool
+		expectedIsAll bool
+	}{
+		"all": {
+			selector:      PRRGet{FilePaths: nil},
+			match:         testKptFile,
+			expectedMatch: true,
+			expectedIsAll: true,
+		},
+		"match": {
+			selector:      PRRGet{FilePaths: []string{testKptFile, testReadmeFile}},
+			match:         testKptFile,
+			expectedMatch: true,
+			expectedIsAll: false,
+		},
+		"mismatch": {
+			selector:      PRRGet{FilePaths: []string{testReadmeFile}},
+			match:         testKptFile,
+			expectedMatch: false,
+			expectedIsAll: false,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			// when
+			match := tc.selector.MatchesFilePath(tc.match)
+			isAll := tc.selector.IsAllFiles()
+
+			// then
+			assert.Equal(t, tc.expectedMatch, match, "expected match")
+			assert.Equal(t, tc.expectedIsAll, isAll, "expected is all")
+		})
+	}
+}

--- a/test/e2e/api/advanced_test.go
+++ b/test/e2e/api/advanced_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
 	porchapi "github.com/kptdev/porch/api/porch/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
 	"github.com/kptdev/porch/test/e2e/suiteutils"
@@ -470,7 +471,10 @@ func (t *PorchSuite) TestPackageMetadataFromKptfile() {
 		}
 
 		var packageResources porchapi.PackageRevisionResources
-		t.GetF(client.ObjectKeyFromObject(clonePr), &packageResources)
+		prKey := client.ObjectKeyFromObject(clonePr)
+		prKey.Name = fmt.Sprintf("%s?file=%s", prKey.Name, kptfilev1.KptFileName)
+		t.GetF(prKey, &packageResources)
+		t.Require().Len(packageResources.Spec.Resources, 1)
 		kptfile := t.ParseKptfileF(&packageResources)
 		t.Require().Equal(expectedLabels, kptfile.Labels)
 		for k, v := range expectedAnnotations {
@@ -480,25 +484,83 @@ func (t *PorchSuite) TestPackageMetadataFromKptfile() {
 		}
 	})
 
-	t.Run("Manual Kptfile metadata update", func() {
+	t.Run("Manual Kptfile metadata partial update", func() {
 		var packageResources porchapi.PackageRevisionResources
 		t.GetF(client.ObjectKeyFromObject(clonePr), &packageResources)
+		originalResourcesLen := len(packageResources.Spec.Resources)
 		kptfile := t.ParseKptfileF(&packageResources)
-		kptfile.Labels["porch.dev/test-label"] = "added-by-e2e-test"
-		kptfile.Annotations["porch.dev/test-annotation"] = "e2e-test-annotation-value"
+		kptfile.Labels["porch.dev/update-test-label"] = "added-by-e2e-update-test"
+		kptfile.Annotations["porch.dev/update-test-annotation"] = "e2e-update-test-annotation-value"
+		packageResources.Name = fmt.Sprintf("%s?partial=true", packageResources.Name)
+		packageResources.Spec.Resources = map[string]string{}
 		t.SaveKptfileF(&packageResources, kptfile)
+		t.Require().Len(packageResources.Spec.Resources, 1)
 		t.UpdateF(&packageResources)
+
+		kptFileAsStr, ok := packageResources.Spec.Resources[kptfilev1.KptFileName]
+		t.Require().True(ok)
+		t.Require().Contains(kptFileAsStr, "added-by-e2e-update-test")
+		t.GetF(client.ObjectKeyFromObject(clonePr), clonePr)
+		expectedLabelsAfterManual := map[string]string{
+			"test-label":                  "test-value",
+			"porch.dev/new-label":         "new-label-value",
+			"porch.dev/update-test-label": "added-by-e2e-update-test",
+		}
+		expectedAnnotationsAfterManual := map[string]string{
+			"test-annotation":                  "true",
+			"porch.dev/new-annotation":         "new-annotation-value",
+			"porch.dev/update-test-annotation": "e2e-update-test-annotation-value",
+		}
+
+		t.Require().NotNil(clonePr.Spec.PackageMetadata)
+		t.Require().Equal(expectedLabelsAfterManual, clonePr.Spec.PackageMetadata.Labels)
+		for k, v := range expectedAnnotationsAfterManual {
+			actual, ok := clonePr.Spec.PackageMetadata.Annotations[k]
+			t.Require().True(ok)
+			t.Require().Equal(v, actual)
+		}
+
+		packageResources.Name = clonePr.Name
+		t.GetF(client.ObjectKeyFromObject(clonePr), &packageResources)
+		t.Require().Len(packageResources.Spec.Resources, originalResourcesLen)
+		kptfile = t.ParseKptfileF(&packageResources)
+		t.Require().Equal(expectedLabelsAfterManual, kptfile.Labels)
+		for k, v := range expectedAnnotationsAfterManual {
+			actual, ok := kptfile.Annotations[k]
+			t.Require().True(ok)
+			t.Require().Equal(v, actual)
+		}
+	})
+
+	t.Run("Manual Kptfile metadata patch", func() {
+		var packageResources porchapi.PackageRevisionResources
+		t.GetF(client.ObjectKeyFromObject(clonePr), &packageResources)
+		originalResourcesLen := len(packageResources.Spec.Resources)
+		patch := client.StrategicMergeFrom(packageResources.DeepCopy())
+		kptfile := t.ParseKptfileF(&packageResources)
+		kptfile.Labels["porch.dev/patch-test-label"] = "added-by-e2e-patch-test"
+		kptfile.Annotations["porch.dev/patch-test-annotation"] = "e2e-patch-test-annotation-value"
+		t.SaveKptfileF(&packageResources, kptfile)
+		t.PatchF(&packageResources, patch)
+		t.Require().Len(packageResources.Spec.Resources, originalResourcesLen)
+		//t.WaitForRender(&packageResources)
+		t.Require().Len(packageResources.Spec.Resources, originalResourcesLen)
+		kptFileAsStr, ok := packageResources.Spec.Resources[kptfilev1.KptFileName]
+		t.Require().True(ok)
+		t.Require().Contains(kptFileAsStr, "added-by-e2e-patch-test")
 		t.GetF(client.ObjectKeyFromObject(clonePr), clonePr)
 
 		expectedLabelsAfterManual := map[string]string{
-			"test-label":           "test-value",
-			"porch.dev/new-label":  "new-label-value",
-			"porch.dev/test-label": "added-by-e2e-test",
+			"test-label":                  "test-value",
+			"porch.dev/new-label":         "new-label-value",
+			"porch.dev/update-test-label": "added-by-e2e-update-test",
+			"porch.dev/patch-test-label":  "added-by-e2e-patch-test",
 		}
 		expectedAnnotationsAfterManual := map[string]string{
-			"test-annotation":           "true",
-			"porch.dev/new-annotation":  "new-annotation-value",
-			"porch.dev/test-annotation": "e2e-test-annotation-value",
+			"test-annotation":                  "true",
+			"porch.dev/new-annotation":         "new-annotation-value",
+			"porch.dev/update-test-annotation": "e2e-update-test-annotation-value",
+			"porch.dev/patch-test-annotation":  "e2e-patch-test-annotation-value",
 		}
 
 		t.Require().NotNil(clonePr.Spec.PackageMetadata)

--- a/test/e2e/api/advanced_test.go
+++ b/test/e2e/api/advanced_test.go
@@ -497,6 +497,7 @@ func (t *PorchSuite) TestPackageMetadataFromKptfile() {
 		t.Require().Len(packageResources.Spec.Resources, 1)
 		t.UpdateF(&packageResources)
 
+		t.Require().Len(packageResources.Spec.Resources, 1)
 		kptFileAsStr, ok := packageResources.Spec.Resources[kptfilev1.KptFileName]
 		t.Require().True(ok)
 		t.Require().Contains(kptFileAsStr, "added-by-e2e-update-test")

--- a/test/mockery/mocks/porch/pkg/cache/dbcache/mock_dbSQLInterface.go
+++ b/test/mockery/mocks/porch/pkg/cache/dbcache/mock_dbSQLInterface.go
@@ -386,3 +386,72 @@ func (_c *MockdbSQLInterface_QueryRow_Call) RunAndReturn(run func(ctx context.Co
 	_c.Call.Return(run)
 	return _c
 }
+
+// ScanTwoTextColumns provides a mock function for the type MockdbSQLInterface
+func (_mock *MockdbSQLInterface) ScanTwoTextColumns(ctx context.Context, query string, args []any, scan func(col1 string, col2 string) error) error {
+	ret := _mock.Called(ctx, query, args, scan)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ScanTwoTextColumns")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []any, func(col1 string, col2 string) error) error); ok {
+		r0 = returnFunc(ctx, query, args, scan)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockdbSQLInterface_ScanTwoTextColumns_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ScanTwoTextColumns'
+type MockdbSQLInterface_ScanTwoTextColumns_Call struct {
+	*mock.Call
+}
+
+// ScanTwoTextColumns is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query string
+//   - args []any
+//   - scan func(col1 string, col2 string) error
+func (_e *MockdbSQLInterface_Expecter) ScanTwoTextColumns(ctx interface{}, query interface{}, args interface{}, scan interface{}) *MockdbSQLInterface_ScanTwoTextColumns_Call {
+	return &MockdbSQLInterface_ScanTwoTextColumns_Call{Call: _e.mock.On("ScanTwoTextColumns", ctx, query, args, scan)}
+}
+
+func (_c *MockdbSQLInterface_ScanTwoTextColumns_Call) Run(run func(ctx context.Context, query string, args []any, scan func(col1 string, col2 string) error)) *MockdbSQLInterface_ScanTwoTextColumns_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []any
+		if args[2] != nil {
+			arg2 = args[2].([]any)
+		}
+		var arg3 func(col1 string, col2 string) error
+		if args[3] != nil {
+			arg3 = args[3].(func(col1 string, col2 string) error)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockdbSQLInterface_ScanTwoTextColumns_Call) Return(err error) *MockdbSQLInterface_ScanTwoTextColumns_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockdbSQLInterface_ScanTwoTextColumns_Call) RunAndReturn(run func(ctx context.Context, query string, args []any, scan func(col1 string, col2 string) error) error) *MockdbSQLInterface_ScanTwoTextColumns_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/test/mockery/mocks/porch/pkg/engine/mock_CaDEngine.go
+++ b/test/mockery/mocks/porch/pkg/engine/mock_CaDEngine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kptdev/porch/api/porchconfig/v1alpha1"
 	"github.com/kptdev/porch/pkg/engine"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -445,8 +446,8 @@ func (_c *MockCaDEngine_ObjectCache_Call) RunAndReturn(run func() engine.Watcher
 }
 
 // UpdatePackageResources provides a mock function for the type MockCaDEngine
-func (_mock *MockCaDEngine) UpdatePackageResources(ctx context.Context, repositoryObj *v1alpha1.Repository, oldPackage repository.PackageRevision, old *v1alpha10.PackageRevisionResources, new *v1alpha10.PackageRevisionResources) (repository.PackageRevision, *v1alpha10.RenderStatus, error) {
-	ret := _mock.Called(ctx, repositoryObj, oldPackage, old, new)
+func (_mock *MockCaDEngine) UpdatePackageResources(ctx context.Context, repositoryObj *v1alpha1.Repository, oldPackage repository.PackageRevision, old *v1alpha10.PackageRevisionResources, new *v1alpha10.PackageRevisionResources, resourceSelector selector.PRRUpdate) (repository.PackageRevision, *v1alpha10.RenderStatus, error) {
+	ret := _mock.Called(ctx, repositoryObj, oldPackage, old, new, resourceSelector)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdatePackageResources")
@@ -455,25 +456,25 @@ func (_mock *MockCaDEngine) UpdatePackageResources(ctx context.Context, reposito
 	var r0 repository.PackageRevision
 	var r1 *v1alpha10.RenderStatus
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1alpha1.Repository, repository.PackageRevision, *v1alpha10.PackageRevisionResources, *v1alpha10.PackageRevisionResources) (repository.PackageRevision, *v1alpha10.RenderStatus, error)); ok {
-		return returnFunc(ctx, repositoryObj, oldPackage, old, new)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1alpha1.Repository, repository.PackageRevision, *v1alpha10.PackageRevisionResources, *v1alpha10.PackageRevisionResources, selector.PRRUpdate) (repository.PackageRevision, *v1alpha10.RenderStatus, error)); ok {
+		return returnFunc(ctx, repositoryObj, oldPackage, old, new, resourceSelector)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1alpha1.Repository, repository.PackageRevision, *v1alpha10.PackageRevisionResources, *v1alpha10.PackageRevisionResources) repository.PackageRevision); ok {
-		r0 = returnFunc(ctx, repositoryObj, oldPackage, old, new)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1alpha1.Repository, repository.PackageRevision, *v1alpha10.PackageRevisionResources, *v1alpha10.PackageRevisionResources, selector.PRRUpdate) repository.PackageRevision); ok {
+		r0 = returnFunc(ctx, repositoryObj, oldPackage, old, new, resourceSelector)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(repository.PackageRevision)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *v1alpha1.Repository, repository.PackageRevision, *v1alpha10.PackageRevisionResources, *v1alpha10.PackageRevisionResources) *v1alpha10.RenderStatus); ok {
-		r1 = returnFunc(ctx, repositoryObj, oldPackage, old, new)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *v1alpha1.Repository, repository.PackageRevision, *v1alpha10.PackageRevisionResources, *v1alpha10.PackageRevisionResources, selector.PRRUpdate) *v1alpha10.RenderStatus); ok {
+		r1 = returnFunc(ctx, repositoryObj, oldPackage, old, new, resourceSelector)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*v1alpha10.RenderStatus)
 		}
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, *v1alpha1.Repository, repository.PackageRevision, *v1alpha10.PackageRevisionResources, *v1alpha10.PackageRevisionResources) error); ok {
-		r2 = returnFunc(ctx, repositoryObj, oldPackage, old, new)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, *v1alpha1.Repository, repository.PackageRevision, *v1alpha10.PackageRevisionResources, *v1alpha10.PackageRevisionResources, selector.PRRUpdate) error); ok {
+		r2 = returnFunc(ctx, repositoryObj, oldPackage, old, new, resourceSelector)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -491,11 +492,12 @@ type MockCaDEngine_UpdatePackageResources_Call struct {
 //   - oldPackage repository.PackageRevision
 //   - old *v1alpha10.PackageRevisionResources
 //   - new *v1alpha10.PackageRevisionResources
-func (_e *MockCaDEngine_Expecter) UpdatePackageResources(ctx interface{}, repositoryObj interface{}, oldPackage interface{}, old interface{}, new interface{}) *MockCaDEngine_UpdatePackageResources_Call {
-	return &MockCaDEngine_UpdatePackageResources_Call{Call: _e.mock.On("UpdatePackageResources", ctx, repositoryObj, oldPackage, old, new)}
+//   - resourceSelector selector.PRRUpdate
+func (_e *MockCaDEngine_Expecter) UpdatePackageResources(ctx interface{}, repositoryObj interface{}, oldPackage interface{}, old interface{}, new interface{}, resourceSelector interface{}) *MockCaDEngine_UpdatePackageResources_Call {
+	return &MockCaDEngine_UpdatePackageResources_Call{Call: _e.mock.On("UpdatePackageResources", ctx, repositoryObj, oldPackage, old, new, resourceSelector)}
 }
 
-func (_c *MockCaDEngine_UpdatePackageResources_Call) Run(run func(ctx context.Context, repositoryObj *v1alpha1.Repository, oldPackage repository.PackageRevision, old *v1alpha10.PackageRevisionResources, new *v1alpha10.PackageRevisionResources)) *MockCaDEngine_UpdatePackageResources_Call {
+func (_c *MockCaDEngine_UpdatePackageResources_Call) Run(run func(ctx context.Context, repositoryObj *v1alpha1.Repository, oldPackage repository.PackageRevision, old *v1alpha10.PackageRevisionResources, new *v1alpha10.PackageRevisionResources, resourceSelector selector.PRRUpdate)) *MockCaDEngine_UpdatePackageResources_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -517,12 +519,17 @@ func (_c *MockCaDEngine_UpdatePackageResources_Call) Run(run func(ctx context.Co
 		if args[4] != nil {
 			arg4 = args[4].(*v1alpha10.PackageRevisionResources)
 		}
+		var arg5 selector.PRRUpdate
+		if args[5] != nil {
+			arg5 = args[5].(selector.PRRUpdate)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
 			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -533,7 +540,7 @@ func (_c *MockCaDEngine_UpdatePackageResources_Call) Return(packageRevision repo
 	return _c
 }
 
-func (_c *MockCaDEngine_UpdatePackageResources_Call) RunAndReturn(run func(ctx context.Context, repositoryObj *v1alpha1.Repository, oldPackage repository.PackageRevision, old *v1alpha10.PackageRevisionResources, new *v1alpha10.PackageRevisionResources) (repository.PackageRevision, *v1alpha10.RenderStatus, error)) *MockCaDEngine_UpdatePackageResources_Call {
+func (_c *MockCaDEngine_UpdatePackageResources_Call) RunAndReturn(run func(ctx context.Context, repositoryObj *v1alpha1.Repository, oldPackage repository.PackageRevision, old *v1alpha10.PackageRevisionResources, new *v1alpha10.PackageRevisionResources, resourceSelector selector.PRRUpdate) (repository.PackageRevision, *v1alpha10.RenderStatus, error)) *MockCaDEngine_UpdatePackageResources_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/test/mockery/mocks/porch/pkg/repository/mock_PackageRevision.go
+++ b/test/mockery/mocks/porch/pkg/repository/mock_PackageRevision.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kptdev/kpt/api/kptfile/v1"
 	"github.com/kptdev/porch/api/porch/v1alpha1"
 	"github.com/kptdev/porch/pkg/repository"
+	"github.com/kptdev/porch/pkg/util/selector"
 	mock "github.com/stretchr/testify/mock"
 	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -92,6 +93,74 @@ func (_c *MockPackageRevision_GetCommitInfo_Call) Return(time1 time.Time, s stri
 }
 
 func (_c *MockPackageRevision_GetCommitInfo_Call) RunAndReturn(run func() (time.Time, string)) *MockPackageRevision_GetCommitInfo_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetFilteredResources provides a mock function for the type MockPackageRevision
+func (_mock *MockPackageRevision) GetFilteredResources(ctx context.Context, resourceSelector selector.PRRGet) (*v1alpha1.PackageRevisionResources, error) {
+	ret := _mock.Called(ctx, resourceSelector)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFilteredResources")
+	}
+
+	var r0 *v1alpha1.PackageRevisionResources
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, selector.PRRGet) (*v1alpha1.PackageRevisionResources, error)); ok {
+		return returnFunc(ctx, resourceSelector)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, selector.PRRGet) *v1alpha1.PackageRevisionResources); ok {
+		r0 = returnFunc(ctx, resourceSelector)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.PackageRevisionResources)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, selector.PRRGet) error); ok {
+		r1 = returnFunc(ctx, resourceSelector)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPackageRevision_GetFilteredResources_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFilteredResources'
+type MockPackageRevision_GetFilteredResources_Call struct {
+	*mock.Call
+}
+
+// GetFilteredResources is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceSelector selector.PRRGet
+func (_e *MockPackageRevision_Expecter) GetFilteredResources(ctx interface{}, resourceSelector interface{}) *MockPackageRevision_GetFilteredResources_Call {
+	return &MockPackageRevision_GetFilteredResources_Call{Call: _e.mock.On("GetFilteredResources", ctx, resourceSelector)}
+}
+
+func (_c *MockPackageRevision_GetFilteredResources_Call) Run(run func(ctx context.Context, resourceSelector selector.PRRGet)) *MockPackageRevision_GetFilteredResources_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 selector.PRRGet
+		if args[1] != nil {
+			arg1 = args[1].(selector.PRRGet)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPackageRevision_GetFilteredResources_Call) Return(packageRevisionResources *v1alpha1.PackageRevisionResources, err error) *MockPackageRevision_GetFilteredResources_Call {
+	_c.Call.Return(packageRevisionResources, err)
+	return _c
+}
+
+func (_c *MockPackageRevision_GetFilteredResources_Call) RunAndReturn(run func(ctx context.Context, resourceSelector selector.PRRGet) (*v1alpha1.PackageRevisionResources, error)) *MockPackageRevision_GetFilteredResources_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

<!-- Short, descriptive title for the PR -->
# [access/update a single file via the prr api]

---

## Description
<!-- Describe what this PR does and why -->
- What changed: Limit the scope of Get and Update PRR calls to a single file.
- Why it’s needed: Prevent to download all the unneccessary content in case of large packages for better performance.
- How it works: Get or Update individual files on a PackageRevisionResources object instead of always transferring the whole package. On GET, query parameters like ?file=Kptfile are parsed from the resource name and only those paths are returned; on UPDATE, ?partial=true merges the submitted files into the existing package, leaves omitted files unchanged, then runs the usual render pipeline.

---

## Related Issue(s)
<!-- Link issues using #ISSUE_NUMBER -->
- Closes/Fixes # https://github.com/kptdev/porch/issues/915

---

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [x] Documentation
- [x] Tests
- [ ] Other: ________

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [x] Documentation added/updated
- [ ] All tests and gating checks pass

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Cursor's grok 4.6 was used to review the changes.
