### PR TITLE
Publish v1.6 documentation and update latest release pointer

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -68,7 +68,7 @@ archived_version = false
 version = "latest"
 
 # The version of the latest code build
-latestTag = "1.5.7"
+latestTag = "1.6.3"
 
 # latest tested versions
 version_docker = "v28.0.4"

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -5,6 +5,11 @@
     "path": "/"
   },
   {
+    "version": "v1.6",
+    "tagPattern": "v1.6.*",
+    "path": "/v1.6/"
+  },
+  {
     "version": "v1.5",
     "tagPattern": "v1.5.*",
     "path": "/v1.5/"


### PR DESCRIPTION
 ## Description
  - **What changed:** Added a `v1.6` entry to `docs/versions.json` so the versioned documentation build publishes the 1.6 release docs at `/v1.6/`, and bumped `latestTag` in `docs/config.toml` from `1.5.7` to `1.6.3` (without prefix 'v') so the main-site install/uninstall instructions point at the current latest release.
  - **Why it's needed:** `v1.6` is released (latest tag `v1.6.3`) but the docs site only published `v1.5`. The `latestTag` value had also gone stale at `1.5.7`, so the install commands on the main site referenced an outdated release.
  - **How it works:** `build-versioned-docs.sh` reads `versions.json` and resolves each `tagPattern` to the highest matching tag - `v1.6.*` -> `v1.6.3`, `v1.5.*` -> `v1.5.12` - building `/v1.6/` and `/v1.5/` alongside the main (`/`) site. `latestTag` is consumed via `{{% params "latestTag" %}}` in the installing-porch, installing-porchctl, uninstalling-porch, and crd-ref pages for the main-site build.

  ## Type of Change
  - [x] Documentation

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [x] Documentation added/updated

  ## AI Disclosure
  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to verify the released tags, validate the changes, and draft this PR description.